### PR TITLE
(Possible) Ollama parsing fix

### DIFF
--- a/lib/providers/ollama.zsh
+++ b/lib/providers/ollama.zsh
@@ -35,7 +35,7 @@ EOF
     # Call the API
     response=$(curl -s "${ZSH_AI_OLLAMA_URL}/api/generate" \
         --header "content-type: application/json" \
-        --data "$json_payload" 2>&1)
+        --data "$json_payload")
     
     if [[ $? -ne 0 ]]; then
         echo "Error: Failed to connect to Ollama. Is it running?"

--- a/lib/widget.zsh
+++ b/lib/widget.zsh
@@ -31,7 +31,8 @@ _zsh_ai_accept_line() {
         setopt local_options no_monitor no_notify
         
         # Start the API query in background
-        (_zsh_ai_query "$query" > "$tmpfile" 2>&1) &
+        # Only redirect stdout to tmpfile, let stderr go to /dev/null to avoid mixing error output
+        (_zsh_ai_query "$query" > "$tmpfile" 2>/dev/null) &
         local pid=$!
         
         # Animate while waiting


### PR DESCRIPTION
### Summary

  This PR is an attempt to fix an issue where Ollama integration fails with "Unable to parse Ollama response" when
   using custom models, even though the API returns valid JSON responses.

###  Problem

  After the animated loading spinner update (da4dd55), the background process implementation
  started capturing both stdout and stderr to the same temp file:

```bash
  (_zsh_ai_query "$query" > "$tmpfile" 2>&1) &
```

  This caused stderr output (curl progress, warnings, debug info) to be mixed with the actual JSON
  response, making it unparseable. Custom Ollama models were particularly affected as they may
  produce more verbose stderr output.

  #### Solution

  Redirect stderr to `/dev/null` to ensure only the clean JSON response is captured:

```bash
  (_zsh_ai_query "$query" > "$tmpfile" 2>/dev/null) &
```

#20 