### PR TITLE
fix missing thinkingConfig block in gemini json payload

### DIFF
--- a/lib/providers/gemini.zsh
+++ b/lib/providers/gemini.zsh
@@ -35,7 +35,9 @@ _zsh_ai_query_gemini() {
     "generationConfig": {
         "temperature": 0.3,
         "maxOutputTokens": 256,
-        "thinkingBudget": 0
+        "thinkingConfig": {
+            "thinkingBudget": 0
+        }
     }
 }
 EOF


### PR DESCRIPTION
Fix related to this issue: #28 