### PR TITLE
Add openai-compatible provider support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,7 +96,16 @@ export ZSH_AI_OPENAI_MODEL="gpt-4o-mini"
 export ZSH_AI_OPENAI_URL="https://<your-openai>/v1/chat/completions"
 ```
 
-**Option 4: Ollama (local models)**
+**Option 4: OpenAI-compatible endpoints**
+```bash
+# For local or third-party OpenAI-compatible APIs (LM Studio, LocalAI, etc.)
+export ZSH_AI_PROVIDER="openai-compatible"
+export ZSH_AI_OPENAI_URL="http://localhost:8080/v1/chat/completions"
+export ZSH_AI_OPENAI_MODEL="your-model-name"
+# OPENAI_API_KEY is optional - set it if your endpoint requires authentication
+```
+
+**Option 5: Ollama (local models)**
 ```bash
 # Run a model (e.g., 3.2)
 ollama run llama3.2
@@ -105,10 +114,10 @@ ollama run llama3.2
 export ZSH_AI_PROVIDER="ollama"
 ```
 
-**Option 5: Perplexity**
+**Option 6: Perplexity**
 ```bash
 export OPENAI_API_KEY="pplx-your-api-key"
-export ZSH_AI_PROVIDER="openai"
+export ZSH_AI_PROVIDER="openai-compatible"
 export ZSH_AI_OPENAI_URL="https://api.perplexity.ai/chat/completions"
 export ZSH_AI_OPENAI_MODEL="llama-3.1-sonar-small-128k-online"
 ```
@@ -120,7 +129,7 @@ Add to your `~/.zshrc` to make it permanent.
 All configuration is done via environment variables with sensible defaults:
 
 ```bash
-# Choose AI provider: "anthropic" (default), "gemini", "openai", or "ollama"
+# Choose AI provider: "anthropic" (default), "gemini", "openai", "openai-compatible", or "ollama"
 export ZSH_AI_PROVIDER="anthropic"
 
 # Anthropic-specific settings

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -17,8 +17,8 @@
 
 # Provider validation
 _zsh_ai_validate_config() {
-    if [[ "$ZSH_AI_PROVIDER" != "anthropic" ]] && [[ "$ZSH_AI_PROVIDER" != "ollama" ]] && [[ "$ZSH_AI_PROVIDER" != "gemini" ]] && [[ "$ZSH_AI_PROVIDER" != "openai" ]]; then
-        echo "zsh-ai: Error: Invalid provider '$ZSH_AI_PROVIDER'. Use 'anthropic', 'ollama', 'gemini', or 'openai'."
+    if [[ "$ZSH_AI_PROVIDER" != "anthropic" ]] && [[ "$ZSH_AI_PROVIDER" != "ollama" ]] && [[ "$ZSH_AI_PROVIDER" != "gemini" ]] && [[ "$ZSH_AI_PROVIDER" != "openai" ]] && [[ "$ZSH_AI_PROVIDER" != "openai-compatible" ]]; then
+        echo "zsh-ai: Error: Invalid provider '$ZSH_AI_PROVIDER'. Use 'anthropic', 'ollama', 'gemini', 'openai', or 'openai-compatible'."
         return 1
     fi
 

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -35,7 +35,7 @@ _zsh_ai_query() {
         _zsh_ai_query_ollama "$query"
     elif [[ "$ZSH_AI_PROVIDER" == "gemini" ]]; then
         _zsh_ai_query_gemini "$query"
-    elif [[ "$ZSH_AI_PROVIDER" == "openai" ]]; then
+    elif [[ "$ZSH_AI_PROVIDER" == "openai" ]] || [[ "$ZSH_AI_PROVIDER" == "openai-compatible" ]]; then
         _zsh_ai_query_openai "$query"
     else
         _zsh_ai_query_anthropic "$query"
@@ -68,8 +68,9 @@ zsh-ai() {
             echo "Ollama model: $ZSH_AI_OLLAMA_MODEL"
         elif [[ "$ZSH_AI_PROVIDER" == "gemini" ]]; then
             echo "Gemini model: $ZSH_AI_GEMINI_MODEL"
-        elif [[ "$ZSH_AI_PROVIDER" == "openai" ]]; then
+        elif [[ "$ZSH_AI_PROVIDER" == "openai" ]] || [[ "$ZSH_AI_PROVIDER" == "openai-compatible" ]]; then
             echo "OpenAI model: $ZSH_AI_OPENAI_MODEL"
+            echo "OpenAI URL: $ZSH_AI_OPENAI_URL"
         fi
         return 1
     fi


### PR DESCRIPTION
I run an openai compatible server on my computer that acts as a proxy. It does not require an API key. I imagine others that run llama.cpp will encounter the same issue.

I made a provider `openai-compatible` that basically just does not give the OPENAI_API_KEY not set warning.

Here is how I configure it:

```
export ZSH_AI_PROVIDER="openai-compatible"
export ZSH_AI_OPENAI_MODEL="claude-haiku-4.5"
export ZSH_AI_OPENAI_URL="http://localhost:4141/v1/chat/completions"
```