### PR TITLE
Add config file support alongside environment variables

### DIFF
--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -2,6 +2,44 @@
 
 # Configuration and validation for zsh-ai
 
+# Load config from file (XDG-compliant location)
+# Config file location: $XDG_CONFIG_HOME/zsh-ai/config or ~/.config/zsh-ai/config
+_zsh_ai_load_config_file() {
+    local config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/zsh-ai"
+    local config_file="$config_dir/config"
+
+    [[ -f "$config_file" ]] && source "$config_file"
+}
+
+# Save user-set environment variables before loading defaults/config file
+# This ensures environment variables always take precedence over config file
+local _user_set_provider=${ZSH_AI_PROVIDER+x}
+local _user_val_provider="$ZSH_AI_PROVIDER"
+local _user_set_ollama_model=${ZSH_AI_OLLAMA_MODEL+x}
+local _user_val_ollama_model="$ZSH_AI_OLLAMA_MODEL"
+local _user_set_ollama_url=${ZSH_AI_OLLAMA_URL+x}
+local _user_val_ollama_url="$ZSH_AI_OLLAMA_URL"
+local _user_set_gemini_model=${ZSH_AI_GEMINI_MODEL+x}
+local _user_val_gemini_model="$ZSH_AI_GEMINI_MODEL"
+local _user_set_openai_model=${ZSH_AI_OPENAI_MODEL+x}
+local _user_val_openai_model="$ZSH_AI_OPENAI_MODEL"
+local _user_set_openai_url=${ZSH_AI_OPENAI_URL+x}
+local _user_val_openai_url="$ZSH_AI_OPENAI_URL"
+local _user_set_anthropic_model=${ZSH_AI_ANTHROPIC_MODEL+x}
+local _user_val_anthropic_model="$ZSH_AI_ANTHROPIC_MODEL"
+local _user_set_anthropic_url=${ZSH_AI_ANTHROPIC_URL+x}
+local _user_val_anthropic_url="$ZSH_AI_ANTHROPIC_URL"
+local _user_set_grok_model=${ZSH_AI_GROK_MODEL+x}
+local _user_val_grok_model="$ZSH_AI_GROK_MODEL"
+local _user_set_grok_url=${ZSH_AI_GROK_URL+x}
+local _user_val_grok_url="$ZSH_AI_GROK_URL"
+local _user_set_mistral_model=${ZSH_AI_MISTRAL_MODEL+x}
+local _user_val_mistral_model="$ZSH_AI_MISTRAL_MODEL"
+local _user_set_mistral_url=${ZSH_AI_MISTRAL_URL+x}
+local _user_val_mistral_url="$ZSH_AI_MISTRAL_URL"
+local _user_set_prompt_extend=${ZSH_AI_PROMPT_EXTEND+x}
+local _user_val_prompt_extend="$ZSH_AI_PROMPT_EXTEND"
+
 # Set default values for configuration
 : ${ZSH_AI_PROVIDER:="anthropic"}  # Default to anthropic for backwards compatibility
 : ${ZSH_AI_OLLAMA_MODEL:="llama3.2"}  # Popular fast model
@@ -16,9 +54,33 @@
 : ${ZSH_AI_MISTRAL_MODEL:="mistral-small-latest"}  # Default Mistral model
 : ${ZSH_AI_MISTRAL_URL:="https://api.mistral.ai/v1/chat/completions"}  # Default Mistral URL
 
+# Load config file (overrides defaults)
+_zsh_ai_load_config_file
+
+# Restore user-set environment variables (override config file)
+[[ -n "$_user_set_provider" ]] && ZSH_AI_PROVIDER="$_user_val_provider"
+[[ -n "$_user_set_ollama_model" ]] && ZSH_AI_OLLAMA_MODEL="$_user_val_ollama_model"
+[[ -n "$_user_set_ollama_url" ]] && ZSH_AI_OLLAMA_URL="$_user_val_ollama_url"
+[[ -n "$_user_set_gemini_model" ]] && ZSH_AI_GEMINI_MODEL="$_user_val_gemini_model"
+[[ -n "$_user_set_openai_model" ]] && ZSH_AI_OPENAI_MODEL="$_user_val_openai_model"
+[[ -n "$_user_set_openai_url" ]] && ZSH_AI_OPENAI_URL="$_user_val_openai_url"
+[[ -n "$_user_set_anthropic_model" ]] && ZSH_AI_ANTHROPIC_MODEL="$_user_val_anthropic_model"
+[[ -n "$_user_set_anthropic_url" ]] && ZSH_AI_ANTHROPIC_URL="$_user_val_anthropic_url"
+[[ -n "$_user_set_grok_model" ]] && ZSH_AI_GROK_MODEL="$_user_val_grok_model"
+[[ -n "$_user_set_grok_url" ]] && ZSH_AI_GROK_URL="$_user_val_grok_url"
+[[ -n "$_user_set_mistral_model" ]] && ZSH_AI_MISTRAL_MODEL="$_user_val_mistral_model"
+[[ -n "$_user_set_mistral_url" ]] && ZSH_AI_MISTRAL_URL="$_user_val_mistral_url"
+[[ -n "$_user_set_prompt_extend" ]] && ZSH_AI_PROMPT_EXTEND="$_user_val_prompt_extend"
+
 # Optional: Extend the system prompt with custom instructions
 # ZSH_AI_PROMPT_EXTEND - Add custom instructions to the AI prompt without replacing the core prompt
 # Example: export ZSH_AI_PROMPT_EXTEND="Always prefer ripgrep (rg) over grep. Use modern CLI tools when available."
+#
+# Config file support:
+# Create ~/.config/zsh-ai/config (or $XDG_CONFIG_HOME/zsh-ai/config) with settings like:
+#   ZSH_AI_PROVIDER=ollama
+#   ZSH_AI_OLLAMA_MODEL=llama3.2
+# Environment variables always take precedence over config file values.
 
 # Provider validation
 _zsh_ai_validate_config() {

--- a/tests/config.test.zsh
+++ b/tests/config.test.zsh
@@ -79,6 +79,117 @@ test_validates_openai_provider() {
     teardown_test_env
 }
 
+# Config file tests
+test_config_file_loads_provider() {
+    setup_test_env
+    local test_dir=$(create_test_dir)
+    local config_dir="$test_dir/zsh-ai"
+    mkdir -p "$config_dir"
+    echo 'ZSH_AI_PROVIDER=ollama' > "$config_dir/config"
+
+    # Use the test dir as XDG_CONFIG_HOME
+    unset ZSH_AI_PROVIDER
+    export XDG_CONFIG_HOME="$test_dir"
+    source "$PLUGIN_DIR/lib/config.zsh"
+
+    assert_equals "$ZSH_AI_PROVIDER" "ollama"
+
+    cleanup_test_dir "$test_dir"
+    unset XDG_CONFIG_HOME
+    teardown_test_env
+}
+
+test_config_file_loads_model() {
+    setup_test_env
+    local test_dir=$(create_test_dir)
+    local config_dir="$test_dir/zsh-ai"
+    mkdir -p "$config_dir"
+    echo 'ZSH_AI_OLLAMA_MODEL=codellama' > "$config_dir/config"
+
+    unset ZSH_AI_OLLAMA_MODEL
+    export XDG_CONFIG_HOME="$test_dir"
+    source "$PLUGIN_DIR/lib/config.zsh"
+
+    assert_equals "$ZSH_AI_OLLAMA_MODEL" "codellama"
+
+    cleanup_test_dir "$test_dir"
+    unset XDG_CONFIG_HOME
+    teardown_test_env
+}
+
+test_env_var_overrides_config_file() {
+    setup_test_env
+    local test_dir=$(create_test_dir)
+    local config_dir="$test_dir/zsh-ai"
+    mkdir -p "$config_dir"
+    echo 'ZSH_AI_PROVIDER=ollama' > "$config_dir/config"
+
+    # Set env var BEFORE sourcing config
+    export ZSH_AI_PROVIDER="anthropic"
+    export XDG_CONFIG_HOME="$test_dir"
+    source "$PLUGIN_DIR/lib/config.zsh"
+
+    # Env var should win over config file
+    assert_equals "$ZSH_AI_PROVIDER" "anthropic"
+
+    cleanup_test_dir "$test_dir"
+    unset XDG_CONFIG_HOME
+    teardown_test_env
+}
+
+test_works_without_config_file() {
+    setup_test_env
+    local test_dir=$(create_test_dir)
+    # Don't create a config file
+
+    unset ZSH_AI_PROVIDER
+    export XDG_CONFIG_HOME="$test_dir"
+    source "$PLUGIN_DIR/lib/config.zsh"
+
+    # Should fall back to defaults
+    assert_equals "$ZSH_AI_PROVIDER" "anthropic"
+
+    cleanup_test_dir "$test_dir"
+    unset XDG_CONFIG_HOME
+    teardown_test_env
+}
+
+test_xdg_config_home_respected() {
+    setup_test_env
+    local test_dir=$(create_test_dir)
+    local config_dir="$test_dir/zsh-ai"
+    mkdir -p "$config_dir"
+    echo 'ZSH_AI_PROVIDER=gemini' > "$config_dir/config"
+
+    unset ZSH_AI_PROVIDER
+    export XDG_CONFIG_HOME="$test_dir"
+    source "$PLUGIN_DIR/lib/config.zsh"
+
+    assert_equals "$ZSH_AI_PROVIDER" "gemini"
+
+    cleanup_test_dir "$test_dir"
+    unset XDG_CONFIG_HOME
+    teardown_test_env
+}
+
+test_config_file_prompt_extend() {
+    setup_test_env
+    local test_dir=$(create_test_dir)
+    local config_dir="$test_dir/zsh-ai"
+    mkdir -p "$config_dir"
+    echo 'ZSH_AI_PROMPT_EXTEND="Always be concise"' > "$config_dir/config"
+
+    unset ZSH_AI_PROMPT_EXTEND
+    export XDG_CONFIG_HOME="$test_dir"
+    source "$PLUGIN_DIR/lib/config.zsh"
+
+    assert_equals "$ZSH_AI_PROMPT_EXTEND" "Always be concise"
+
+    cleanup_test_dir "$test_dir"
+    unset XDG_CONFIG_HOME
+    teardown_test_env
+}
+
 # Run tests
 echo "Running config tests..."
 test_default_provider && echo "✓ Default provider is anthropic"
@@ -89,3 +200,13 @@ test_validates_ollama_provider && echo "✓ Validates ollama provider"
 test_rejects_invalid_provider && echo "✓ Rejects invalid provider"
 test_validates_gemini_provider && echo "✓ Validates gemini provider"
 test_validates_openai_provider && echo "✓ Validates openai provider"
+
+# Config file tests
+echo ""
+echo "Running config file tests..."
+test_config_file_loads_provider && echo "✓ Config file loads provider"
+test_config_file_loads_model && echo "✓ Config file loads model"
+test_env_var_overrides_config_file && echo "✓ Environment variable overrides config file"
+test_works_without_config_file && echo "✓ Works without config file"
+test_xdg_config_home_respected && echo "✓ XDG_CONFIG_HOME is respected"
+test_config_file_prompt_extend && echo "✓ Config file loads prompt extend"


### PR DESCRIPTION
Add support for loading configuration from ~/.config/zsh-ai/config (or $XDG_CONFIG_HOME/zsh-ai/config) while maintaining full backward compatibility with environment variables.

Loading order ensures backward compatibility:
1. Save user-set environment variables
2. Apply defaults
3. Source config file (if exists)
4. Restore user environment variables (always take precedence)

This allows users to:
- Use a config file instead of exporting env vars in .zshrc
- Mix both approaches (env vars override config file)
- Continue using env vars only (no change in behavior)

Closes #56