### PR TITLE
Add ZSH_AI_OPENAI_API_KEY for OpenAI-compatible proxies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,6 +107,15 @@ export ZSH_AI_OPENAI_MODEL="your-model-name"
 # No API key needed for local servers
 ```
 
+For proxies that require authentication (like LiteLLM), use `ZSH_AI_OPENAI_API_KEY` to avoid conflicts with your real `OPENAI_API_KEY`:
+
+```bash
+export ZSH_AI_PROVIDER="openai"
+export ZSH_AI_OPENAI_URL="http://localhost:4000/v1/chat/completions"
+export ZSH_AI_OPENAI_MODEL="gpt-4"
+export ZSH_AI_OPENAI_API_KEY="sk-your-litellm-key"  # Won't interfere with OPENAI_API_KEY
+```
+
 ### Perplexity
 
 ```bash
@@ -172,6 +181,7 @@ export ZSH_AI_ANTHROPIC_URL="https://api.anthropic.com/v1/messages"
 # OpenAI
 export ZSH_AI_OPENAI_MODEL="gpt-4o"
 export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
+export ZSH_AI_OPENAI_API_KEY=""  # Optional: override OPENAI_API_KEY for proxies
 
 # Gemini
 export ZSH_AI_GEMINI_MODEL="gemini-2.5-flash"

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -43,7 +43,7 @@ _zsh_ai_validate_config() {
     elif [[ "$ZSH_AI_PROVIDER" == "openai" ]]; then
         # Only require API key when using the default OpenAI URL
         # Custom URLs (local servers, proxies) may not need authentication
-        if [[ -z "$OPENAI_API_KEY" && "$ZSH_AI_OPENAI_URL" == "https://api.openai.com/v1/chat/completions" ]]; then
+        if [[ -z "$OPENAI_API_KEY" && -z "$ZSH_AI_OPENAI_API_KEY" && "$ZSH_AI_OPENAI_URL" == "https://api.openai.com/v1/chat/completions" ]]; then
             echo "zsh-ai: Warning: OPENAI_API_KEY not set. Plugin will not function."
             echo "zsh-ai: Set OPENAI_API_KEY or use ZSH_AI_PROVIDER=ollama for local models."
             return 1

--- a/lib/providers/openai.zsh
+++ b/lib/providers/openai.zsh
@@ -42,8 +42,10 @@ EOF
 )
     
     # Call the API - only add auth header if API key is set
+    # ZSH_AI_OPENAI_API_KEY takes precedence (useful for LiteLLM and other proxies)
     local auth_args=()
-    [[ -n "$OPENAI_API_KEY" ]] && auth_args=(--header "Authorization: Bearer $OPENAI_API_KEY")
+    local api_key="${ZSH_AI_OPENAI_API_KEY:-$OPENAI_API_KEY}"
+    [[ -n "$api_key" ]] && auth_args=(--header "Authorization: Bearer $api_key")
 
     response=$(curl -s "${ZSH_AI_OPENAI_URL}" \
         "${auth_args[@]}" \


### PR DESCRIPTION
## Summary

- Adds `ZSH_AI_OPENAI_API_KEY` environment variable that takes precedence over `OPENAI_API_KEY`
- Enables users to configure authentication for OpenAI-compatible proxies (like LiteLLM) without conflicting with their real `OPENAI_API_KEY`
- Fully backwards compatible—falls back to `OPENAI_API_KEY` when not set

## Problem

When using OpenAI-compatible servers that require authentication (like LiteLLM running as a proxy), users currently have to set `OPENAI_API_KEY`. This causes issues when other tools on the system expect `OPENAI_API_KEY` to contain a real OpenAI key.

## Solution

Add `ZSH_AI_OPENAI_API_KEY` following the existing naming convention (`ZSH_AI_OPENAI_URL`, `ZSH_AI_OPENAI_MODEL`). When set, it's used for authentication instead of `OPENAI_API_KEY`.

**Example usage:**
```bash
export ZSH_AI_PROVIDER="openai"
export ZSH_AI_OPENAI_URL="http://localhost:4000/v1/chat/completions"
export ZSH_AI_OPENAI_MODEL="gpt-4"
export ZSH_AI_OPENAI_API_KEY="sk-litellm-key"  # Won't interfere with OPENAI_API_KEY
```

## Test plan

- [x] All existing tests pass (165/165)
- [x] Manual test with LiteLLM proxy using OPENAI_API_KEY (backwards compat)
- [x] Verify ZSH_AI_OPENAI_API_KEY takes precedence when set