### PR TITLE
Add ability to use Claude Code CLI

### DIFF
--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -15,6 +15,7 @@
 : ${ZSH_AI_GROK_URL:="https://api.x.ai/v1/chat/completions"}  # Default Grok URL
 : ${ZSH_AI_MISTRAL_MODEL:="mistral-small-latest"}  # Default Mistral model
 : ${ZSH_AI_MISTRAL_URL:="https://api.mistral.ai/v1/chat/completions"}  # Default Mistral URL
+: ${ZSH_AI_CLAUDE_CODE_MODEL:="claude-haiku-4-5"}  # Default Claude Code model (avoids burning Opus tokens)
 
 # Optional: Extend the system prompt with custom instructions
 # ZSH_AI_PROMPT_EXTEND - Add custom instructions to the AI prompt without replacing the core prompt
@@ -22,8 +23,8 @@
 
 # Provider validation
 _zsh_ai_validate_config() {
-    if [[ "$ZSH_AI_PROVIDER" != "anthropic" ]] && [[ "$ZSH_AI_PROVIDER" != "ollama" ]] && [[ "$ZSH_AI_PROVIDER" != "gemini" ]] && [[ "$ZSH_AI_PROVIDER" != "openai" ]] && [[ "$ZSH_AI_PROVIDER" != "grok" ]] && [[ "$ZSH_AI_PROVIDER" != "mistral" ]]; then
-        echo "zsh-ai: Error: Invalid provider '$ZSH_AI_PROVIDER'. Use 'anthropic', 'ollama', 'gemini', 'openai', 'grok', or 'mistral'."
+    if [[ "$ZSH_AI_PROVIDER" != "anthropic" ]] && [[ "$ZSH_AI_PROVIDER" != "ollama" ]] && [[ "$ZSH_AI_PROVIDER" != "gemini" ]] && [[ "$ZSH_AI_PROVIDER" != "openai" ]] && [[ "$ZSH_AI_PROVIDER" != "grok" ]] && [[ "$ZSH_AI_PROVIDER" != "mistral" ]] && [[ "$ZSH_AI_PROVIDER" != "claude-code" ]]; then
+        echo "zsh-ai: Error: Invalid provider '$ZSH_AI_PROVIDER'. Use 'anthropic', 'ollama', 'gemini', 'openai', 'grok', 'mistral', or 'claude-code'."
         return 1
     fi
 

--- a/lib/providers/claude-code.zsh
+++ b/lib/providers/claude-code.zsh
@@ -1,0 +1,46 @@
+#!/usr/bin/env zsh
+
+# Claude Code CLI provider for zsh-ai
+
+# Function to check if Claude Code CLI is installed
+_zsh_ai_check_claude_code() {
+    command -v claude &> /dev/null
+    return $?
+}
+
+# Function to query via Claude Code CLI
+_zsh_ai_query_claude_code() {
+    local query="$1"
+    local response
+
+    # Build context
+    local context=$(_zsh_ai_build_context)
+    local system_prompt=$(_zsh_ai_get_system_prompt "$context")
+
+    # Build command arguments
+    local -a cmd_args
+    cmd_args=(claude -p "$query" --system-prompt "$system_prompt" --output-format text --max-turns 1)
+
+    # Add model override if configured
+    if [[ -n "$ZSH_AI_CLAUDE_CODE_MODEL" ]]; then
+        cmd_args+=(--model "$ZSH_AI_CLAUDE_CODE_MODEL")
+    fi
+
+    # Call claude CLI
+    response=$("${cmd_args[@]}" 2>&1)
+
+    if [[ $? -ne 0 ]]; then
+        echo "Error: Failed to run claude CLI"
+        return 1
+    fi
+
+    if [[ -z "$response" ]]; then
+        echo "Error: Empty response from claude CLI"
+        return 1
+    fi
+
+    # Clean up the response - remove markdown code fences, newlines, and trailing whitespace
+    local result
+    result=$(printf "%s" "$response" | sed 's/^```[a-z]*$//' | tr -d '\n' | sed 's/[[:space:]]*$//')
+    printf "%s" "$result"
+}

--- a/lib/providers/claude-code.zsh
+++ b/lib/providers/claude-code.zsh
@@ -28,9 +28,14 @@ _zsh_ai_query_claude_code() {
 
     # Call claude CLI
     response=$("${cmd_args[@]}" 2>&1)
+    local exit_code=$?
 
-    if [[ $? -ne 0 ]]; then
-        echo "Error: Failed to run claude CLI"
+    if [[ $exit_code -ne 0 ]]; then
+        if [[ -n "$response" ]]; then
+            echo "Error: claude CLI failed: $response"
+        else
+            echo "Error: Failed to run claude CLI (exit code $exit_code)"
+        fi
         return 1
     fi
 

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -41,6 +41,14 @@ _zsh_ai_query() {
         _zsh_ai_query_grok "$query"
     elif [[ "$ZSH_AI_PROVIDER" == "mistral" ]]; then
         _zsh_ai_query_mistral "$query"
+    elif [[ "$ZSH_AI_PROVIDER" == "claude-code" ]]; then
+        # Check if claude CLI is available first
+        if ! _zsh_ai_check_claude_code; then
+            echo "Error: claude CLI not found"
+            echo "Install Claude Code: https://docs.anthropic.com/en/docs/claude-code"
+            return 1
+        fi
+        _zsh_ai_query_claude_code "$query"
     else
         _zsh_ai_query_anthropic "$query"
     fi
@@ -78,6 +86,8 @@ zsh-ai() {
             echo "Grok model: $ZSH_AI_GROK_MODEL"
         elif [[ "$ZSH_AI_PROVIDER" == "mistral" ]]; then
             echo "Mistral model: $ZSH_AI_MISTRAL_MODEL"
+        elif [[ "$ZSH_AI_PROVIDER" == "claude-code" ]]; then
+            echo "Claude Code model: $ZSH_AI_CLAUDE_CODE_MODEL"
         fi
         return 1
     fi

--- a/tests/config.test.zsh
+++ b/tests/config.test.zsh
@@ -79,6 +79,15 @@ test_validates_openai_provider() {
     teardown_test_env
 }
 
+test_validates_claude_code_provider() {
+    setup_test_env
+    export ZSH_AI_PROVIDER="claude-code"
+    _zsh_ai_validate_config >/dev/null 2>&1
+    local result=$?
+    assert_equals "$result" "0"
+    teardown_test_env
+}
+
 # Run tests
 echo "Running config tests..."
 test_default_provider && echo "✓ Default provider is anthropic"
@@ -89,3 +98,4 @@ test_validates_ollama_provider && echo "✓ Validates ollama provider"
 test_rejects_invalid_provider && echo "✓ Rejects invalid provider"
 test_validates_gemini_provider && echo "✓ Validates gemini provider"
 test_validates_openai_provider && echo "✓ Validates openai provider"
+test_validates_claude_code_provider && echo "✓ Validates claude-code provider"

--- a/tests/providers/claude-code.test.zsh
+++ b/tests/providers/claude-code.test.zsh
@@ -1,0 +1,207 @@
+#!/usr/bin/env zsh
+
+# Load test helper
+source "${0:A:h:h}/test_helper.zsh"
+
+# Load the context and claude-code provider modules
+source "$PLUGIN_DIR/lib/utils.zsh"
+source "$PLUGIN_DIR/lib/context.zsh"
+source "$PLUGIN_DIR/lib/config.zsh"
+source "$PLUGIN_DIR/lib/providers/claude-code.zsh"
+
+# Test functions
+
+test_check_claude_code_installed_success() {
+    setup_test_env
+
+    # Mock claude as available
+    mock_command "claude" "" 0
+
+    _zsh_ai_check_claude_code
+    local result=$?
+
+    assert_equals "$result" "0"
+
+    teardown_test_env
+}
+
+test_check_claude_code_installed_failure() {
+    setup_test_env
+
+    # Ensure claude is not found
+    command() {
+        if [[ "$1" == "-v" ]] && [[ "$2" == "claude" ]]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
+
+    _zsh_ai_check_claude_code
+    local result=$?
+
+    assert_equals "$result" "1"
+
+    teardown_test_env
+}
+
+test_successful_query() {
+    setup_test_env
+    export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
+
+    # Mock claude CLI to return a command
+    mock_command "claude" "ls -la" 0
+
+    local output
+    output=$(_zsh_ai_query_claude_code "list all files")
+    local result=$?
+
+    assert_equals "$result" "0"
+    assert_equals "$output" "ls -la"
+
+    teardown_test_env
+}
+
+test_handles_cli_failure() {
+    setup_test_env
+    export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
+
+    # Mock claude CLI failure
+    mock_command "claude" "" 1
+
+    local output
+    output=$(_zsh_ai_query_claude_code "test query")
+    local result=$?
+
+    assert_equals "$result" "1"
+    assert_contains "$output" "Failed to run claude CLI"
+
+    teardown_test_env
+}
+
+test_handles_empty_response() {
+    setup_test_env
+    export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
+
+    # Mock claude CLI returning empty string
+    mock_command "claude" "" 0
+
+    local output
+    output=$(_zsh_ai_query_claude_code "test query")
+    local result=$?
+
+    assert_equals "$result" "1"
+    assert_contains "$output" "Empty response from claude CLI"
+
+    teardown_test_env
+}
+
+test_strips_markdown_code_fences() {
+    setup_test_env
+    export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
+
+    # Mock claude CLI returning response with markdown fences
+    claude() {
+        printf "git status"
+        return 0
+    }
+
+    local output
+    output=$(_zsh_ai_query_claude_code "show git status")
+    local result=$?
+
+    assert_equals "$result" "0"
+    assert_equals "$output" "git status"
+
+    teardown_test_env
+}
+
+test_removes_trailing_whitespace() {
+    setup_test_env
+    export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
+
+    # Mock claude CLI returning response with trailing whitespace
+    claude() {
+        printf "docker ps -a   "
+        return 0
+    }
+
+    local output
+    output=$(_zsh_ai_query_claude_code "list docker containers")
+    local result=$?
+
+    assert_equals "$result" "0"
+    assert_equals "$output" "docker ps -a"
+
+    teardown_test_env
+}
+
+test_uses_model_from_config() {
+    setup_test_env
+    export ZSH_AI_CLAUDE_CODE_MODEL="claude-sonnet-4-5"
+
+    # Mock claude CLI - just verify it runs
+    mock_command "claude" "npm test" 0
+
+    local output
+    output=$(_zsh_ai_query_claude_code "run tests")
+    local result=$?
+
+    assert_equals "$result" "0"
+    assert_equals "$output" "npm test"
+
+    teardown_test_env
+}
+
+test_includes_context_in_query() {
+    setup_test_env
+    export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
+
+    # Create a test environment with specific context
+    local TEST_DIR=$(create_test_dir)
+    cd "$TEST_DIR"
+    touch Dockerfile
+
+    # Mock claude CLI
+    mock_command "claude" "docker build ." 0
+
+    local output
+    output=$(_zsh_ai_query_claude_code "build docker image")
+    local result=$?
+
+    assert_equals "$result" "0"
+    assert_equals "$output" "docker build ."
+
+    cd - >/dev/null 2>&1
+    cleanup_test_dir "$TEST_DIR"
+    teardown_test_env
+}
+
+test_escapes_quotes_in_query() {
+    setup_test_env
+    export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
+
+    # Mock claude CLI
+    mock_command "claude" 'echo "test"' 0
+
+    local output
+    output=$(_zsh_ai_query_claude_code 'print "test"')
+    local result=$?
+
+    assert_equals "$result" "0"
+    assert_equals "$output" 'echo "test"'
+
+    teardown_test_env
+}
+
+# Run tests
+echo "Running claude-code provider tests..."
+test_check_claude_code_installed_success && echo "✓ Check if claude CLI is installed - success"
+test_check_claude_code_installed_failure && echo "✓ Check if claude CLI is installed - failure"
+test_successful_query && echo "✓ Successful query"
+test_handles_cli_failure && echo "✓ Handles CLI failure"
+test_handles_empty_response && echo "✓ Handles empty response"
+test_strips_markdown_code_fences && echo "✓ Strips markdown code fences"
+test_removes_trailing_whitespace && echo "✓ Removes trailing whitespace"
+test_uses_model_from_config && echo "✓ Uses model from config"
+test_includes_context_in_query && echo "✓ Includes context in query"
+test_escapes_quotes_in_query && echo "✓ Escapes quotes in query"

--- a/tests/providers/claude-code.test.zsh
+++ b/tests/providers/claude-code.test.zsh
@@ -78,6 +78,23 @@ test_handles_cli_failure() {
     teardown_test_env
 }
 
+test_surfaces_cli_error_output() {
+    setup_test_env
+    export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
+
+    # Mock claude CLI failure with error message (e.g. auth failure)
+    mock_command "claude" "Not authenticated. Run claude login." 1
+
+    local output
+    output=$(_zsh_ai_query_claude_code "test query")
+    local result=$?
+
+    assert_equals "$result" "1"
+    assert_contains "$output" "Not authenticated"
+
+    teardown_test_env
+}
+
 test_handles_empty_response() {
     setup_test_env
     export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
@@ -99,9 +116,9 @@ test_strips_markdown_code_fences() {
     setup_test_env
     export ZSH_AI_CLAUDE_CODE_MODEL="claude-haiku-4-5"
 
-    # Mock claude CLI returning response with markdown fences
+    # Mock claude CLI returning response wrapped in markdown fences
     claude() {
-        printf "git status"
+        printf '%s\n' '```sh' 'git status' '```'
         return 0
     }
 
@@ -199,6 +216,7 @@ test_check_claude_code_installed_success && echo "✓ Check if claude CLI is ins
 test_check_claude_code_installed_failure && echo "✓ Check if claude CLI is installed - failure"
 test_successful_query && echo "✓ Successful query"
 test_handles_cli_failure && echo "✓ Handles CLI failure"
+test_surfaces_cli_error_output && echo "✓ Surfaces CLI error output"
 test_handles_empty_response && echo "✓ Handles empty response"
 test_strips_markdown_code_fences && echo "✓ Strips markdown code fences"
 test_removes_trailing_whitespace && echo "✓ Removes trailing whitespace"

--- a/tests/test_helper.zsh
+++ b/tests/test_helper.zsh
@@ -163,6 +163,7 @@ teardown_test_env() {
     unfunction command 2>/dev/null
     unfunction jq 2>/dev/null
     unfunction curl 2>/dev/null
+    unfunction claude 2>/dev/null
     unset ZSH_AI_PROVIDER
     unset ANTHROPIC_API_KEY
     unset ZSH_AI_MODEL

--- a/zsh-ai.plugin.zsh
+++ b/zsh-ai.plugin.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 # zsh-ai - AI-powered command suggestions for zsh
-# Supports Anthropic Claude, Google Gemini, OpenAI, Mistral AI, and local Ollama models
+# Supports Anthropic Claude, Google Gemini, OpenAI, Mistral AI, local Ollama models, and Claude Code CLI
 
 # Get the directory where this plugin is installed
 local plugin_dir="${0:A:h}"
@@ -15,6 +15,7 @@ source "${plugin_dir}/lib/providers/gemini.zsh"
 source "${plugin_dir}/lib/providers/openai.zsh"
 source "${plugin_dir}/lib/providers/grok.zsh"
 source "${plugin_dir}/lib/providers/mistral.zsh"
+source "${plugin_dir}/lib/providers/claude-code.zsh"
 source "${plugin_dir}/lib/utils.zsh"
 source "${plugin_dir}/lib/widget.zsh"
 

--- a/zsh-ai.plugin.zsh
+++ b/zsh-ai.plugin.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 # zsh-ai - AI-powered command suggestions for zsh
-# Supports Anthropic Claude, Google Gemini, OpenAI, Mistral AI, local Ollama models, and Claude Code CLI
+# Supports Anthropic Claude, Google Gemini, OpenAI, Grok, Mistral AI, local Ollama models, and Claude Code CLI
 
 # Get the directory where this plugin is installed
 local plugin_dir="${0:A:h}"


### PR DESCRIPTION
# Add claude-code provider for CLI-based auth without API keys (#63)

Adds a new claude-code provider that uses the Claude Code CLI (claude) instead of direct API calls. This lets users who have Claude Code installed

skip managing API keys entirely — authentication is handled by the CLI.

### Usage:
`export ZSH_AI_PROVIDER="claude-code"`
# Optionally override the model (defaults to claude-haiku-4-5)
`export ZSH_AI_CLAUDE_CODE_MODEL="claude-sonnet-4-5"`

###  What's included:
  - New provider at lib/providers/claude-code.zsh
  - CLI availability check with a helpful install link on failure
  - Markdown code fence stripping (handles ```sh ``` wrapped responses)
  - Trailing whitespace cleanup
  - Configurable model via ZSH_AI_CLAUDE_CODE_MODEL
  - 11 new tests covering success, failure, empty responses, fence stripping, and error surfacing