### PR TITLE
Update default OpenAI and Qwen models to modern tiers

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -188,7 +188,7 @@ export ZSH_AI_ANTHROPIC_MODEL="claude-haiku-4-5"
 export ZSH_AI_ANTHROPIC_URL="https://api.anthropic.com/v1/messages"
 
 # OpenAI
-export ZSH_AI_OPENAI_MODEL="gpt-4o"
+export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
 export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
 export ZSH_AI_OPENAI_API_KEY=""  # Optional: override OPENAI_API_KEY for proxies
 
@@ -208,7 +208,7 @@ export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
 export ZSH_AI_GROK_URL="https://api.x.ai/v1/chat/completions"
 
 # Qwen
-export ZSH_AI_QWEN_MODEL="qwen3-max"
+export ZSH_AI_QWEN_MODEL="qwen-plus"
 export ZSH_AI_QWEN_URL="https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
 ```
 

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -7,9 +7,9 @@
 : ${ZSH_AI_OLLAMA_MODEL:="llama3.2"}  # Popular fast model
 : ${ZSH_AI_OLLAMA_URL:="http://localhost:11434"}  # Default Ollama URL
 : ${ZSH_AI_GEMINI_MODEL:="gemini-2.5-flash"}  # Fast Gemini 2.5 model
-: ${ZSH_AI_OPENAI_MODEL:="gpt-4o"}  # Default to GPT-4o
+: ${ZSH_AI_OPENAI_MODEL:="gpt-5-mini"}  # Default to GPT-5 mini
 : ${ZSH_AI_OPENAI_URL:="https://api.openai.com/v1/chat/completions"}  # Default to OpenAI
-: ${ZSH_AI_QWEN_MODEL:="qwen3-max"}  # Default to qwen3-max
+: ${ZSH_AI_QWEN_MODEL:="qwen-plus"}  # Default to qwen-plus
 : ${ZSH_AI_QWEN_URL:="https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"}  # Default to Qwen API
 : ${ZSH_AI_ANTHROPIC_MODEL:="claude-haiku-4-5"}  # Default Anthropic model
 : ${ZSH_AI_ANTHROPIC_URL:="https://api.anthropic.com/v1/messages"}  # Default Anthropic URL

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -32,7 +32,7 @@ EOF
 
 test_openai_query_success() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-4o"
+    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
 
     local result=$(_zsh_ai_query_openai "list files")
     assert_equals "$result" "ls -la"
@@ -40,7 +40,7 @@ test_openai_query_success() {
 
 test_openai_query_error_response() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-4o"
+    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
     
     # Override curl to return an error
     curl() {
@@ -63,7 +63,7 @@ EOF
 
 test_openai_json_escaping() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-4o"
+    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
     
     # Test with special characters
     local result=$(_zsh_ai_query_openai "test \"quotes\" and \$variables")
@@ -73,7 +73,7 @@ test_openai_json_escaping() {
 
 test_handles_response_with_newline() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-4o"
+    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
     export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
 
     # Override curl to return response with newline
@@ -101,7 +101,7 @@ EOF
 
 test_handles_response_without_jq() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-4o"
+    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
 
     # Mock jq as unavailable
     command() {
@@ -150,7 +150,7 @@ test_uses_perplexity_url() {
 
 test_uses_max_tokens_for_gpt4_models() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-4o"
+    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
     export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
     local payload_file=$(mktemp)
 
@@ -387,7 +387,7 @@ test_openai_zsh_ai_key_takes_precedence() {
     export OPENAI_API_KEY="original-key"
     export ZSH_AI_OPENAI_API_KEY="override-key"
     export ZSH_AI_PROVIDER="openai"
-    export ZSH_AI_OPENAI_MODEL="gpt-4o"
+    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
     export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
     local curl_args_file=$(mktemp)
 
@@ -420,7 +420,7 @@ test_openai_falls_back_to_openai_api_key() {
     unset ZSH_AI_OPENAI_API_KEY
     export OPENAI_API_KEY="fallback-key"
     export ZSH_AI_PROVIDER="openai"
-    export ZSH_AI_OPENAI_MODEL="gpt-4o"
+    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
     export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
     local curl_args_file=$(mktemp)
 

--- a/tests/providers/qwen.test.zsh
+++ b/tests/providers/qwen.test.zsh
@@ -32,7 +32,7 @@ EOF
 
 test_qwen_query_success() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen3-max"
+    export ZSH_AI_QWEN_MODEL="qwen-plus"
 
     local result=$(_zsh_ai_query_qwen "list files")
     assert_equals "$result" "ls -la"
@@ -40,7 +40,7 @@ test_qwen_query_success() {
 
 test_qwen_query_error_response() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen3-max"
+    export ZSH_AI_QWEN_MODEL="qwen-plus"
 
     # Override curl to return an error
     curl() {
@@ -63,7 +63,7 @@ EOF
 
 test_qwen_json_escaping() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen3-max"
+    export ZSH_AI_QWEN_MODEL="qwen-plus"
 
     # Test with special characters
     local result=$(_zsh_ai_query_qwen "test \"quotes\" and \$variables")
@@ -73,7 +73,7 @@ test_qwen_json_escaping() {
 
 test_handles_response_with_newline() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen3-max"
+    export ZSH_AI_QWEN_MODEL="qwen-plus"
 
     # Override curl to return response with newline
     curl() {
@@ -100,7 +100,7 @@ EOF
 
 test_handles_response_without_jq() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen3-max"
+    export ZSH_AI_QWEN_MODEL="qwen-plus"
 
     # Mock jq as unavailable
     command() {
@@ -125,7 +125,7 @@ test_handles_response_without_jq() {
 
 test_uses_configurable_api_url() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen3-max"
+    export ZSH_AI_QWEN_MODEL="qwen-plus"
     export ZSH_AI_QWEN_URL="https://custom.qwen.api/v1/chat/completions"
 
     # Override curl to check the custom URL is used
@@ -146,7 +146,7 @@ test_uses_configurable_api_url() {
 
 test_uses_max_tokens() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen3-max"
+    export ZSH_AI_QWEN_MODEL="qwen-plus"
     local payload_file=$(mktemp)
 
     curl() {
@@ -173,7 +173,7 @@ test_uses_max_tokens() {
 
 test_uses_qwen_api_key() {
     export QWEN_API_KEY="test-secret-key"
-    export ZSH_AI_QWEN_MODEL="qwen3-max"
+    export ZSH_AI_QWEN_MODEL="qwen-plus"
     local curl_args_file=$(mktemp)
 
     curl() {


### PR DESCRIPTION
## Summary
- Bump OpenAI default from `gpt-4o` to `gpt-5-mini`
- Bump Qwen default from `qwen3-max` to `qwen-plus`
- Both are faster and cheaper, better suited to the CLI command-suggester workload. Other provider defaults (Anthropic, Gemini, Grok, Mistral, Ollama) were audited against live docs and left unchanged.

## Test plan
- [x] `./run-tests.zsh` passes (178/178)
- [ ] Manually verify a real call against OpenAI with the new default
- [ ] Manually verify a real call against Qwen with the new default