### PR TITLE
feat(gemini): support Vertex AI routing and header auth

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,14 +52,37 @@ export ZSH_AI_PROVIDER="openai"
 
 [Get your API key →](https://platform.openai.com/api-keys)
 
-### Google Gemini
+### Google Gemini / Vertex AI
+
+You can use either Google AI Studio (default) or Google Cloud Vertex AI.
+
+**For Google AI Studio:**
 
 ```bash
 export GEMINI_API_KEY="your-api-key-here"
 export ZSH_AI_PROVIDER="gemini"
 ```
 
-[Get your API key →](https://makersuite.google.com/app/apikey)
+[Get your API key →](https://aistudio.google.com/app/apikey)
+
+**For Vertex AI:**
+
+If you are using Vertex AI, you need to provide your Google Cloud Project ID using `GEMINI_` prefixed variables.
+
+```bash
+export GEMINI_API_KEY="your-gcp-api-key-here" # Must have Vertex AI permissions
+export GEMINI_CLOUD_PROJECT="my-awesome-project"
+export ZSH_AI_PROVIDER="gemini"
+
+# (Optional) Set the region if you don't want to use the default "global" routing:
+# export GEMINI_CLOUD_REGION="us-central1" 
+```
+
+*If you already have standard Google Cloud CLI environment variables set up, you can simply map them over in your `~/.zshrc`:*
+```bash
+export GEMINI_CLOUD_PROJECT=$GOOGLE_CLOUD_PROJECT
+export GEMINI_CLOUD_REGION=$GOOGLE_CLOUD_REGION
+```
 
 ### Ollama (Local & Free)
 
@@ -192,8 +215,10 @@ export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
 export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
 export ZSH_AI_OPENAI_API_KEY=""  # Optional: override OPENAI_API_KEY for proxies
 
-# Gemini
+# Gemini / Vertex AI
 export ZSH_AI_GEMINI_MODEL="gemini-2.5-flash"
+export GEMINI_CLOUD_PROJECT="" # Optional: Set to use Vertex AI
+export GEMINI_CLOUD_REGION="" # Optional: Vertex AI region (defaults to global)
 
 # Ollama
 export ZSH_AI_OLLAMA_MODEL="llama3.2"

--- a/lib/providers/gemini.zsh
+++ b/lib/providers/gemini.zsh
@@ -45,8 +45,28 @@ _zsh_ai_query_gemini() {
 EOF
 )
     
+    # Determine the endpoint based on project and region variables
+    local endpoint
+    if [[ -z "${GEMINI_CLOUD_PROJECT}" ]]; then
+        # Google AI Studio Fallback
+        endpoint="https://generativelanguage.googleapis.com/v1beta/models/${ZSH_AI_GEMINI_MODEL}:generateContent"
+    else
+        # Vertex AI Routing
+        local domain
+        local location
+        if [[ -z "${GEMINI_CLOUD_REGION}" || "${GEMINI_CLOUD_REGION}" == "global" ]]; then
+            location="global"
+            domain="https://aiplatform.googleapis.com"
+        else
+            location="${GEMINI_CLOUD_REGION}"
+            domain="https://${GEMINI_CLOUD_REGION}-aiplatform.googleapis.com"
+        fi
+        endpoint="${domain}/v1/projects/${GEMINI_CLOUD_PROJECT}/locations/${location}/publishers/google/models/${ZSH_AI_GEMINI_MODEL}:generateContent"
+    fi
+
     # Call the API
-    response=$(curl -s "https://generativelanguage.googleapis.com/v1beta/models/${ZSH_AI_GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}" \
+    response=$(curl -s "$endpoint" \
+        --header "x-goog-api-key: ${GEMINI_API_KEY}" \
         --header "content-type: application/json" \
         --data "$json_payload" 2>&1)
     

--- a/tests/providers/gemini.test.zsh
+++ b/tests/providers/gemini.test.zsh
@@ -14,10 +14,17 @@ source "$PLUGIN_DIR/lib/providers/gemini.zsh"
 test_default_model_configuration() {
     setup_test_env
     
+    # Save the original env var and unset it so we test the default
+    local orig_model="$ZSH_AI_GEMINI_MODEL"
+    unset ZSH_AI_GEMINI_MODEL
+    
     # Source config to get default values
     source "$PLUGIN_DIR/lib/config.zsh"
     
-    assert_equals "$ZSH_AI_GEMINI_MODEL" "gemini-2.0-flash"
+    assert_equals "$ZSH_AI_GEMINI_MODEL" "gemini-2.5-flash"
+    
+    # Restore the original env var
+    export ZSH_AI_GEMINI_MODEL="$orig_model"
     
     teardown_test_env
 }
@@ -80,6 +87,75 @@ test_gemini_query_function_exists() {
     fi
     
     assert_equals "$result" "0"
+    
+    teardown_test_env
+}
+
+test_routes_queries_to_ai_studio_by_default() {
+    setup_test_env
+    export GEMINI_API_KEY="test-api-key"
+    export ZSH_AI_GEMINI_MODEL="gemini-2.5-flash"
+    unset GEMINI_CLOUD_PROJECT
+    unset GEMINI_CLOUD_REGION
+    
+    # Mock jq as available
+    mock_jq "true"
+    
+    # Mock successful curl response
+    local mock_response='{"candidates":[{"content":{"parts":[{"text":"git status"}]}}]}'
+    mock_curl_response "$mock_response" 0
+    
+    _zsh_ai_query_gemini "show git status" > /dev/null
+    
+    local curl_args=$(cat "$MOCK_CURL_ARGS_FILE")
+    assert_contains "$curl_args" "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+    assert_contains "$curl_args" "x-goog-api-key: test-api-key"
+    
+    teardown_test_env
+}
+
+test_routes_queries_to_vertex_ai_global() {
+    setup_test_env
+    export GEMINI_API_KEY="test-api-key"
+    export GEMINI_CLOUD_PROJECT="my-project"
+    export ZSH_AI_GEMINI_MODEL="gemini-2.5-flash"
+    unset GEMINI_CLOUD_REGION
+    
+    # Mock jq as available
+    mock_jq "true"
+    
+    # Mock successful curl response
+    local mock_response='{"candidates":[{"content":{"parts":[{"text":"git status"}]}}]}'
+    mock_curl_response "$mock_response" 0
+    
+    _zsh_ai_query_gemini "show git status" > /dev/null
+    
+    local curl_args=$(cat "$MOCK_CURL_ARGS_FILE")
+    assert_contains "$curl_args" "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global/publishers/google/models/gemini-2.5-flash:generateContent"
+    assert_contains "$curl_args" "x-goog-api-key: test-api-key"
+    
+    teardown_test_env
+}
+
+test_routes_queries_to_vertex_ai_regional() {
+    setup_test_env
+    export GEMINI_API_KEY="test-api-key"
+    export GEMINI_CLOUD_PROJECT="my-project"
+    export GEMINI_CLOUD_REGION="us-central1"
+    export ZSH_AI_GEMINI_MODEL="gemini-2.5-flash"
+    
+    # Mock jq as available
+    mock_jq "true"
+    
+    # Mock successful curl response
+    local mock_response='{"candidates":[{"content":{"parts":[{"text":"git status"}]}}]}'
+    mock_curl_response "$mock_response" 0
+    
+    _zsh_ai_query_gemini "show git status" > /dev/null
+    
+    local curl_args=$(cat "$MOCK_CURL_ARGS_FILE")
+    assert_contains "$curl_args" "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent"
+    assert_contains "$curl_args" "x-goog-api-key: test-api-key"
     
     teardown_test_env
 }
@@ -159,7 +235,7 @@ test_handles_curl_connection_failure() {
     local result=$?
     
     assert_equals "$result" "1"
-    assert_contains "$output" "Failed to connect to Google AI API"
+    assert_contains "$output" "Failed to connect to Gemini API"
     
     teardown_test_env
 }
@@ -234,6 +310,9 @@ test_validation_fails_without_api_key && echo "✓ Validation fails without API 
 test_validation_succeeds_with_api_key && echo "✓ Validation succeeds with API key"
 test_routes_queries_to_gemini_provider && echo "✓ Routes queries to gemini provider"
 test_gemini_query_function_exists && echo "✓ Gemini query function exists"
+test_routes_queries_to_ai_studio_by_default && echo "✓ Routes queries to AI Studio by default"
+test_routes_queries_to_vertex_ai_global && echo "✓ Routes queries to Vertex AI (Global)"
+test_routes_queries_to_vertex_ai_regional && echo "✓ Routes queries to Vertex AI (Regional)"
 test_successful_api_call_with_jq && echo "✓ Successful API call with jq available"
 test_successful_api_call_without_jq && echo "✓ Successful API call without jq"
 test_handles_api_error_response && echo "✓ Handles API error response"

--- a/tests/test_helper.zsh
+++ b/tests/test_helper.zsh
@@ -69,15 +69,19 @@ mock_curl_response() {
     local exit_code="${2:-0}"
     
     # Store response and exit code in global variables
-    MOCK_CURL_RESPONSE="$response"
-    MOCK_CURL_EXIT_CODE="$exit_code"
+    export MOCK_CURL_RESPONSE="$response"
+    export MOCK_CURL_EXIT_CODE="$exit_code"
+    export MOCK_CURL_ARGS_FILE=$(mktemp)
     
     # Create a global curl function
     function curl() {
+        # Log arguments to file since this might be run in a subshell
+        print -r -- "$@" > "$MOCK_CURL_ARGS_FILE"
+
         if [[ "$MOCK_CURL_EXIT_CODE" -ne 0 ]]; then
             return "$MOCK_CURL_EXIT_CODE"
         fi
-        echo "$MOCK_CURL_RESPONSE"
+        print -r -- "$MOCK_CURL_RESPONSE"
         return 0
     }
 }
@@ -122,7 +126,7 @@ mock_jq() {
                 result=$(echo "$input" | perl -0777 -ne 'if (/"response":\s*"([^"\\]*(\\.[^"\\]*)*)"/) { $val = $1; $val =~ s/\\n/\n/g; $val =~ s/\\"/"/g; print $val; }')
             elif [[ "$args" == *".candidates[0].content.parts[0].text"* ]]; then
                 # For Gemini responses
-                result=$(echo "$input" | grep -o '"text":"[^"]*"' | head -1 | sed 's/"text":"\([^"]*\)"/\1/')
+                result=$(print -r -- "$input" | grep -o '"text":"[^"]*"' | head -1 | sed 's/"text":"\([^"]*\)"/\1/')
             fi
             
             # Return result or empty based on // empty handling
@@ -159,6 +163,10 @@ setup_test_env() {
 # Teardown test environment
 teardown_test_env() {
     reset_mocks
+    # Clean up curl mock temp file if it exists
+    if [[ -n "$MOCK_CURL_ARGS_FILE" && -f "$MOCK_CURL_ARGS_FILE" ]]; then
+        rm -f "$MOCK_CURL_ARGS_FILE"
+    fi
     # Unfunction any mocked commands
     unfunction command 2>/dev/null
     unfunction jq 2>/dev/null


### PR DESCRIPTION
## Pre-text 🧑‍🤝‍🧑 

Trying to get Gemini up and running with this plugin in the context of my Google environment, which is using Vertex AI. Gemini pointed out the differing domains involved and the need for a Google project ID. This PR adds a switch to the domain routing based on the presence of the ID (explicitly not from the common global GOOGLE_CLOUD_PROJECT) and sends the API key over the `x-goog-api-key` header.

## Description 🤖 

This PR introduces support for **Google Cloud Vertex AI** routing and improves the security of how the Gemini API key is transmitted.

### Key Changes
* **Security Improvement**: Transmits the Gemini API key securely via the `x-goog-api-key` HTTP header rather than exposing it as a URL query parameter (`?key=...`).
* **Vertex AI Support**: Implements dynamic endpoint resolution. Setting `GEMINI_CLOUD_PROJECT` will automatically route requests to the correct Vertex AI endpoint instead of the default Google AI Studio endpoint.
* **Regional Routing**: Supports `GEMINI_CLOUD_REGION` to construct regional Vertex endpoints (defaults to `global`).
* **Documentation**: Updated `INSTALL.md` with clear instructions on how to configure Vertex AI, including a snippet for mapping existing `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_REGION` environment variables.
* **Testing**: Added comprehensive test coverage for endpoint construction to ensure robust AI Studio fallback and accurate Vertex AI regional routing.

### Backwards Compatibility
Complete backward compatibility is maintained. If `GEMINI_CLOUD_PROJECT` is omitted, the plugin gracefully falls back to the default `generativelanguage.googleapis.com` AI Studio endpoint.