### PR TITLE
Reap background API job to prevent stale job count in prompt

### DIFF
--- a/lib/widget.zsh
+++ b/lib/widget.zsh
@@ -44,9 +44,12 @@ _zsh_ai_accept_line() {
             zle -R && sleep 0.1
         done
         
+        # Reap the background job so it doesn't linger in the job table
+        wait $pid 2>/dev/null
+        local exit_code=$?
+
         # Get the response
         local cmd=$(cat "$tmpfile")
-        local exit_code=$?
         rm -f "$tmpfile"
         
         if [[ -n "$cmd" ]] && [[ "$cmd" != "Error:"* ]] && [[ "$cmd" != "API Error:"* ]]; then


### PR DESCRIPTION
## Problem

`_zsh_ai_accept_line` spawns the provider request as a background job (`(...) &`)
and polls it with `kill -0`, but never `wait`s on it. The completed job lingers
in zsh's job table, so prompts that count background jobs (e.g. starship's `jobs`
module) show a phantom job (`✦`) until the next command or a manual `jobs` reaps it.

Separately, `local exit_code=$?` after `cat "$tmpfile"` captured `cat`'s exit
status rather than the request's.

## Fix

`wait $pid` after the spinner loop reaps the job and lets `exit_code` capture the
request's real exit status. No added latency — the process has already exited by
the time the loop ends.

## Repro

With starship's `jobs` module enabled, type a `# ...` query and press Enter; the
prompt shows `✦1` until the next keystroke or command.
