### PR TITLE
Fix test harness failure tracking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,8 @@ test_my_feature() {
 
 # Run tests
 echo "Running my tests..."
-test_my_feature && echo "✓ My feature works"
+run_test "My feature works" test_my_feature
+finish_tests
 ```
 
 To manually verify your changes work:

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -96,7 +96,7 @@ zsh-ai() {
     local tmpfile=$(mktemp)
     
     # Disable job control notifications (same as widget)
-    setopt local_options no_monitor no_notify
+    setopt local_options no_monitor no_notify no_bg_nice
 
     # Start the API query in background
     (_zsh_ai_execute_command "$query" > "$tmpfile" 2>/dev/null) &

--- a/lib/widget.zsh
+++ b/lib/widget.zsh
@@ -28,7 +28,7 @@ _zsh_ai_accept_line() {
         local tmpfile=$(mktemp)
         
         # Disable job control notifications
-        setopt local_options no_monitor no_notify
+        setopt local_options no_monitor no_notify no_bg_nice
         
         # Start the API query in background using the shared function
         # Only redirect stdout to tmpfile, let stderr go to /dev/null to avoid mixing error output
@@ -45,11 +45,12 @@ _zsh_ai_accept_line() {
         done
         
         # Get the response
-        local cmd=$(cat "$tmpfile")
+        wait $pid
         local exit_code=$?
+        local cmd=$(cat "$tmpfile")
         rm -f "$tmpfile"
         
-        if [[ -n "$cmd" ]] && [[ "$cmd" != "Error:"* ]] && [[ "$cmd" != "API Error:"* ]]; then
+        if [[ $exit_code -eq 0 ]] && [[ -n "$cmd" ]] && [[ "$cmd" != "Error:"* ]] && [[ "$cmd" != "API Error:"* ]]; then
             # Simply replace the buffer with the generated command
             BUFFER="$cmd"
 

--- a/run-tests.zsh
+++ b/run-tests.zsh
@@ -86,7 +86,7 @@ main() {
     echo "================================"
     
     # Exit based on results
-    if [[ $TOTAL_FAILED -gt 0 ]]; then
+    if [[ $TOTAL_FAILED -gt 0 || ${#FAILED_FILES} -gt 0 ]]; then
         exit 1
     else
         exit 0

--- a/tests/config.test.zsh
+++ b/tests/config.test.zsh
@@ -81,11 +81,12 @@ test_validates_openai_provider() {
 
 # Run tests
 echo "Running config tests..."
-test_default_provider && echo "✓ Default provider is anthropic"
-test_default_ollama_model && echo "✓ Default Ollama model is llama3.2"
-test_default_ollama_url && echo "✓ Default Ollama URL is localhost:11434"
-test_validates_anthropic_provider && echo "✓ Validates anthropic provider"
-test_validates_ollama_provider && echo "✓ Validates ollama provider"
-test_rejects_invalid_provider && echo "✓ Rejects invalid provider"
-test_validates_gemini_provider && echo "✓ Validates gemini provider"
-test_validates_openai_provider && echo "✓ Validates openai provider"
+run_test "Default provider is anthropic" test_default_provider
+run_test "Default Ollama model is llama3.2" test_default_ollama_model
+run_test "Default Ollama URL is localhost:11434" test_default_ollama_url
+run_test "Validates anthropic provider" test_validates_anthropic_provider
+run_test "Validates ollama provider" test_validates_ollama_provider
+run_test "Rejects invalid provider" test_rejects_invalid_provider
+run_test "Validates gemini provider" test_validates_gemini_provider
+run_test "Validates openai provider" test_validates_openai_provider
+finish_tests

--- a/tests/context.test.zsh
+++ b/tests/context.test.zsh
@@ -366,27 +366,28 @@ test_includes_os_information() {
 
 # Run tests
 echo "Running context tests..."
-test_detects_nodejs_project && echo "✓ Detects Node.js project"
-test_detects_rust_project && echo "✓ Detects Rust project"
-test_detects_python_project_requirements && echo "✓ Detects Python project with requirements.txt"
-test_detects_python_project_setup && echo "✓ Detects Python project with setup.py"
-test_detects_python_project_pyproject && echo "✓ Detects Python project with pyproject.toml"
-test_detects_ruby_project && echo "✓ Detects Ruby project"
-test_detects_go_project && echo "✓ Detects Go project"
-test_detects_php_project && echo "✓ Detects PHP project"
-test_detects_java_project_pom && echo "✓ Detects Java project with pom.xml"
-test_detects_java_project_gradle && echo "✓ Detects Java project with build.gradle"
-test_detects_docker_project_compose && echo "✓ Detects Docker project with docker-compose.yml"
-test_detects_docker_project_dockerfile && echo "✓ Detects Docker project with Dockerfile"
-test_returns_unknown_for_unrecognized_project && echo "✓ Returns unknown for unrecognized project"
-test_returns_empty_for_non_git_directory && echo "✓ Returns empty string for non-git directory"
-test_gets_git_context_for_repository && echo "✓ Gets git context for git repository"
-test_detects_dirty_git_status && echo "✓ Detects dirty git status"
-test_shows_current_directory_in_context && echo "✓ Shows current directory in context"
-test_lists_files_when_less_than_20 && echo "✓ Lists files when less than 20"
-test_truncates_file_list_at_10_files && echo "✓ Truncates file list at 10 files"
-test_shows_file_count_for_many_files && echo "✓ Shows file count for directories with many files"
-test_builds_complete_context && echo "✓ Builds complete context"
-test_builds_context_without_git && echo "✓ Builds context without git"
-test_builds_context_for_unknown_project && echo "✓ Builds context for unknown project"
-test_includes_os_information && echo "✓ Includes OS information"
+run_test "Detects Node.js project" test_detects_nodejs_project
+run_test "Detects Rust project" test_detects_rust_project
+run_test "Detects Python project with requirements.txt" test_detects_python_project_requirements
+run_test "Detects Python project with setup.py" test_detects_python_project_setup
+run_test "Detects Python project with pyproject.toml" test_detects_python_project_pyproject
+run_test "Detects Ruby project" test_detects_ruby_project
+run_test "Detects Go project" test_detects_go_project
+run_test "Detects PHP project" test_detects_php_project
+run_test "Detects Java project with pom.xml" test_detects_java_project_pom
+run_test "Detects Java project with build.gradle" test_detects_java_project_gradle
+run_test "Detects Docker project with docker-compose.yml" test_detects_docker_project_compose
+run_test "Detects Docker project with Dockerfile" test_detects_docker_project_dockerfile
+run_test "Returns unknown for unrecognized project" test_returns_unknown_for_unrecognized_project
+run_test "Returns empty string for non-git directory" test_returns_empty_for_non_git_directory
+run_test "Gets git context for git repository" test_gets_git_context_for_repository
+run_test "Detects dirty git status" test_detects_dirty_git_status
+run_test "Shows current directory in context" test_shows_current_directory_in_context
+run_test "Lists files when less than 20" test_lists_files_when_less_than_20
+run_test "Truncates file list at 10 files" test_truncates_file_list_at_10_files
+run_test "Shows file count for directories with many files" test_shows_file_count_for_many_files
+run_test "Builds complete context" test_builds_complete_context
+run_test "Builds context without git" test_builds_context_without_git
+run_test "Builds context for unknown project" test_builds_context_for_unknown_project
+run_test "Includes OS information" test_includes_os_information
+finish_tests

--- a/tests/json_escape.test.zsh
+++ b/tests/json_escape.test.zsh
@@ -1,22 +1,20 @@
 #!/usr/bin/env zsh
 
 # Test suite for JSON escaping functionality
-source "${0:A:h}/../lib/utils.zsh"
+source "${0:A:h}/test_helper.zsh"
+source "$PLUGIN_DIR/lib/utils.zsh"
 
 # Test helper function
 test_json_escape() {
-    local test_name="$1"
-    local input="$2"
-    local expected="$3"
+    local input="$1"
+    local expected="$2"
     local result=$(_zsh_ai_escape_json "$input")
     
-    if [[ "$result" == "$expected" ]]; then
-        echo "✓ $test_name"
-    else
-        echo "✗ $test_name"
+    if [[ "$result" != "$expected" ]]; then
         printf "  Input:    %q\n" "$input"
         printf "  Expected: %q\n" "$expected"
         printf "  Got:      %q\n" "$result"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -24,40 +22,41 @@ test_json_escape() {
 echo "Testing JSON escaping function..."
 
 # Basic escaping tests
-test_json_escape "Simple string" "hello world" "hello world"
-test_json_escape "Double quotes" 'hello "world"' 'hello \"world\"'
-test_json_escape "Backslashes" 'hello\world' 'hello\\world'
-test_json_escape "Backslash before quote" 'hello\"world' 'hello\\\"world'
+run_test "Simple string" test_json_escape "hello world" "hello world"
+run_test "Double quotes" test_json_escape 'hello "world"' 'hello \"world\"'
+run_test "Backslashes" test_json_escape 'hello\world' 'hello\\world'
+run_test "Backslash before quote" test_json_escape 'hello\"world' 'hello\\\"world'
 
 # Control character tests
-test_json_escape "Newline" $'hello\nworld' $'hello\\nworld'
-test_json_escape "Tab" $'hello\tworld' $'hello\\tworld'
-test_json_escape "Carriage return" $'hello\rworld' $'hello\\rworld'
-test_json_escape "Backspace" $'hello\bworld' $'hello\\bworld'
-test_json_escape "Form feed" $'hello\fworld' $'hello\\fworld'
+run_test "Newline" test_json_escape $'hello\nworld' $'hello\\nworld'
+run_test "Tab" test_json_escape $'hello\tworld' $'hello\\tworld'
+run_test "Carriage return" test_json_escape $'hello\rworld' $'hello\\rworld'
+run_test "Backspace" test_json_escape $'hello\bworld' $'hello\\bworld'
+run_test "Form feed" test_json_escape $'hello\fworld' $'hello\\fworld'
 
 # Complex combinations
-test_json_escape "Multiple escapes" $'line1\n"quoted"\ttab' $'line1\\n\\"quoted\\"\\ttab'
-test_json_escape "Path with spaces" '/Users/name/My Documents/file.txt' '/Users/name/My Documents/file.txt'
-test_json_escape "JSON in string" '{"key": "value"}' '{\"key\": \"value\"}'
+run_test "Multiple escapes" test_json_escape $'line1\n"quoted"\ttab' $'line1\\n\\"quoted\\"\\ttab'
+run_test "Path with spaces" test_json_escape '/Users/name/My Documents/file.txt' '/Users/name/My Documents/file.txt'
+run_test "JSON in string" test_json_escape '{"key": "value"}' '{\"key\": \"value\"}'
 
 # Edge cases
-test_json_escape "Empty string" "" ""
-test_json_escape "Only quotes" '"""' '\"\"\"'
-test_json_escape "Only backslashes" '\\\\' '\\\\\\\\'
-test_json_escape "Mixed control chars" $'start\n\r\t\b\fend' $'start\\n\\r\\t\\b\\fend'
+run_test "Empty string" test_json_escape "" ""
+run_test "Only quotes" test_json_escape '"""' '\"\"\"'
+run_test "Only backslashes" test_json_escape '\\\\' '\\\\\\\\'
+run_test "Mixed control chars" test_json_escape $'start\n\r\t\b\fend' $'start\\n\\r\\t\\b\\fend'
 
 # Test with potential problematic characters from the issue
-test_json_escape "Command with port" "kill process on port 3002" "kill process on port 3002"
+run_test "Command with port" test_json_escape "kill process on port 3002" "kill process on port 3002"
 
 # Test removal of other control characters
-test_json_escape "Null character" $'hello\0world' 'helloworld'
-test_json_escape "Bell character" $'hello\aworld' 'helloworld'
-test_json_escape "Vertical tab" $'hello\vworld' 'helloworld'
+run_test "Null character" test_json_escape $'hello\0world' 'helloworld'
+run_test "Bell character" test_json_escape $'hello\aworld' 'helloworld'
+run_test "Vertical tab" test_json_escape $'hello\vworld' 'helloworld'
 
 # Real-world scenario from context building
-test_json_escape "Directory listing" $'Current directory: /tmp\nFiles: test.txt, data.json' $'Current directory: /tmp\\nFiles: test.txt, data.json'
-test_json_escape "Git status" $'Git: branch=main, status=dirty\nOS: Darwin' $'Git: branch=main, status=dirty\\nOS: Darwin'
+run_test "Directory listing" test_json_escape $'Current directory: /tmp\nFiles: test.txt, data.json' $'Current directory: /tmp\\nFiles: test.txt, data.json'
+run_test "Git status" test_json_escape $'Git: branch=main, status=dirty\nOS: Darwin' $'Git: branch=main, status=dirty\\nOS: Darwin'
 
 echo ""
 echo "All tests completed!"
+finish_tests

--- a/tests/providers/anthropic.test.zsh
+++ b/tests/providers/anthropic.test.zsh
@@ -319,17 +319,18 @@ test_uses_correct_url_from_config() {
 
 # Run tests
 echo "Running anthropic provider tests..."
-test_successful_api_call_with_jq && echo "✓ Successful API call with jq available"
-test_successful_api_call_without_jq && echo "✓ Successful API call without jq"
-test_handles_api_error_response_with_jq && echo "✓ Handles API error response with jq"
-test_handles_curl_connection_failure && echo "✓ Handles curl connection failure"
-test_handles_empty_response_with_jq && echo "✓ Handles empty response with jq"
-test_handles_malformed_response_without_jq && echo "✓ Handles malformed response without jq"
-test_escapes_quotes_in_query && echo "✓ Escapes quotes in query"
-test_includes_context_in_api_call && echo "✓ Includes context in API call"
-test_uses_correct_api_headers && echo "✓ Uses correct API headers"
-test_uses_correct_model && echo "✓ Uses correct model"
-test_handles_multiline_context_properly && echo "✓ Handles multiline context properly"
-test_handles_response_with_escaped_newline_with_jq && echo "✓ Handles response with escaped newline (with jq)"
-test_handles_response_with_escaped_newline_without_jq && echo "✓ Handles response with escaped newline (without jq)"
-test_uses_correct_url_from_config && echo "✓ Uses correct URL from config"
+run_test "Successful API call with jq available" test_successful_api_call_with_jq
+run_test "Successful API call without jq" test_successful_api_call_without_jq
+run_test "Handles API error response with jq" test_handles_api_error_response_with_jq
+run_test "Handles curl connection failure" test_handles_curl_connection_failure
+run_test "Handles empty response with jq" test_handles_empty_response_with_jq
+run_test "Handles malformed response without jq" test_handles_malformed_response_without_jq
+run_test "Escapes quotes in query" test_escapes_quotes_in_query
+run_test "Includes context in API call" test_includes_context_in_api_call
+run_test "Uses correct API headers" test_uses_correct_api_headers
+run_test "Uses correct model" test_uses_correct_model
+run_test "Handles multiline context properly" test_handles_multiline_context_properly
+run_test "Handles response with escaped newline (with jq)" test_handles_response_with_escaped_newline_with_jq
+run_test "Handles response with escaped newline (without jq)" test_handles_response_with_escaped_newline_without_jq
+run_test "Uses correct URL from config" test_uses_correct_url_from_config
+finish_tests

--- a/tests/providers/gemini.test.zsh
+++ b/tests/providers/gemini.test.zsh
@@ -17,7 +17,7 @@ test_default_model_configuration() {
     # Source config to get default values
     source "$PLUGIN_DIR/lib/config.zsh"
     
-    assert_equals "$ZSH_AI_GEMINI_MODEL" "gemini-2.0-flash"
+    assert_equals "$ZSH_AI_GEMINI_MODEL" "gemini-2.5-flash"
     
     teardown_test_env
 }
@@ -159,7 +159,7 @@ test_handles_curl_connection_failure() {
     local result=$?
     
     assert_equals "$result" "1"
-    assert_contains "$output" "Failed to connect to Google AI API"
+    assert_contains "$output" "Failed to connect to Gemini API"
     
     teardown_test_env
 }
@@ -229,15 +229,16 @@ test_handles_response_with_escaped_newline_without_jq() {
 
 # Run tests
 echo "Running gemini provider tests..."
-test_default_model_configuration && echo "✓ Default model configuration"
-test_validation_fails_without_api_key && echo "✓ Validation fails without API key"
-test_validation_succeeds_with_api_key && echo "✓ Validation succeeds with API key"
-test_routes_queries_to_gemini_provider && echo "✓ Routes queries to gemini provider"
-test_gemini_query_function_exists && echo "✓ Gemini query function exists"
-test_successful_api_call_with_jq && echo "✓ Successful API call with jq available"
-test_successful_api_call_without_jq && echo "✓ Successful API call without jq"
-test_handles_api_error_response && echo "✓ Handles API error response"
-test_handles_curl_connection_failure && echo "✓ Handles curl connection failure"
-test_handles_empty_response && echo "✓ Handles empty response"
-test_handles_response_with_escaped_newline_with_jq && echo "✓ Handles response with escaped newline (with jq)"
-test_handles_response_with_escaped_newline_without_jq && echo "✓ Handles response with escaped newline (without jq)"
+run_test "Default model configuration" test_default_model_configuration
+run_test "Validation fails without API key" test_validation_fails_without_api_key
+run_test "Validation succeeds with API key" test_validation_succeeds_with_api_key
+run_test "Routes queries to gemini provider" test_routes_queries_to_gemini_provider
+run_test "Gemini query function exists" test_gemini_query_function_exists
+run_test "Successful API call with jq available" test_successful_api_call_with_jq
+run_test "Successful API call without jq" test_successful_api_call_without_jq
+run_test "Handles API error response" test_handles_api_error_response
+run_test "Handles curl connection failure" test_handles_curl_connection_failure
+run_test "Handles empty response" test_handles_empty_response
+run_test "Handles response with escaped newline (with jq)" test_handles_response_with_escaped_newline_with_jq
+run_test "Handles response with escaped newline (without jq)" test_handles_response_with_escaped_newline_without_jq
+finish_tests

--- a/tests/providers/grok.test.zsh
+++ b/tests/providers/grok.test.zsh
@@ -181,18 +181,14 @@ test_uses_xai_api_key() {
     assert_not_empty "$result"
 }
 
-# Add missing assert_not_empty function
-assert_not_empty() {
-    [[ -n "$1" ]]
-}
-
 # Run tests
 echo "Running Grok provider tests..."
-test_grok_query_success && echo "✓ Grok query success"
-test_grok_query_error_response && echo "✓ Grok error response handling"
-test_grok_json_escaping && echo "✓ Grok JSON escaping"
-test_handles_response_with_newline && echo "✓ Handles response with trailing newline"
-test_handles_response_without_jq && echo "✓ Handles response without jq and with newline"
-test_uses_configurable_api_url && echo "✓ Uses configurable API URL (ZSH_AI_GROK_URL)"
-test_uses_max_completion_tokens && echo "✓ Uses max_completion_tokens parameter"
-test_uses_xai_api_key && echo "✓ Uses XAI_API_KEY environment variable"
+run_test "Grok query success" test_grok_query_success
+run_test "Grok error response handling" test_grok_query_error_response
+run_test "Grok JSON escaping" test_grok_json_escaping
+run_test "Handles response with trailing newline" test_handles_response_with_newline
+run_test "Handles response without jq and with newline" test_handles_response_without_jq
+run_test "Uses configurable API URL (ZSH_AI_GROK_URL)" test_uses_configurable_api_url
+run_test "Uses max_completion_tokens parameter" test_uses_max_completion_tokens
+run_test "Uses XAI_API_KEY environment variable" test_uses_xai_api_key
+finish_tests

--- a/tests/providers/mistral.test.zsh
+++ b/tests/providers/mistral.test.zsh
@@ -298,17 +298,17 @@ test_handles_response_with_escaped_newline_without_jq() {
 
 # Run tests
 echo "Running mistral provider tests..."
-test_successful_api_call_with_jq && echo "✓ Successful API call with jq available"
-test_successful_api_call_without_jq && echo "✓ Successful API call without jq"
-test_handles_api_error_response_with_jq && echo "✓ Handles API error response with jq"
-test_handles_curl_connection_failure && echo "✓ Handles curl connection failure"
-test_handles_empty_response_with_jq && echo "✓ Handles empty response with jq"
-test_handles_malformed_response_without_jq && echo "✓ Handles malformed response without jq"
-test_escapes_quotes_in_query && echo "✓ Escapes quotes in query"
-test_includes_context_in_api_call && echo "✓ Includes context in API call"
-test_uses_correct_api_headers && echo "✓ Uses correct API headers"
-test_uses_correct_model && echo "✓ Uses correct model"
-test_handles_multiline_context_properly && echo "✓ Handles multiline context properly"
-test_handles_response_with_escaped_newline_with_jq && echo "✓ Handles response with escaped newline (with jq)"
-test_handles_response_with_escaped_newline_without_jq && echo "✓ Handles response with escaped newline (without jq)"
-
+run_test "Successful API call with jq available" test_successful_api_call_with_jq
+run_test "Successful API call without jq" test_successful_api_call_without_jq
+run_test "Handles API error response with jq" test_handles_api_error_response_with_jq
+run_test "Handles curl connection failure" test_handles_curl_connection_failure
+run_test "Handles empty response with jq" test_handles_empty_response_with_jq
+run_test "Handles malformed response without jq" test_handles_malformed_response_without_jq
+run_test "Escapes quotes in query" test_escapes_quotes_in_query
+run_test "Includes context in API call" test_includes_context_in_api_call
+run_test "Uses correct API headers" test_uses_correct_api_headers
+run_test "Uses correct model" test_uses_correct_model
+run_test "Handles multiline context properly" test_handles_multiline_context_properly
+run_test "Handles response with escaped newline (with jq)" test_handles_response_with_escaped_newline_with_jq
+run_test "Handles response with escaped newline (without jq)" test_handles_response_with_escaped_newline_without_jq
+finish_tests

--- a/tests/providers/ollama.test.zsh
+++ b/tests/providers/ollama.test.zsh
@@ -403,21 +403,22 @@ test_handles_thinking_model_response() {
 
 # Run tests
 echo "Running ollama provider tests..."
-test_check_ollama_running_success && echo "✓ Check if Ollama is running - success"
-test_check_ollama_running_failure && echo "✓ Check if Ollama is running - failure"
-test_successful_api_call_with_jq && echo "✓ Successful API call with jq available"
-test_successful_api_call_without_jq && echo "✓ Successful API call without jq"
-test_handles_api_error_response_with_jq && echo "✓ Handles API error response with jq"
-test_handles_curl_connection_failure && echo "✓ Handles curl connection failure"
-test_handles_empty_response_with_jq && echo "✓ Handles empty response with jq"
-test_handles_malformed_response_without_jq && echo "✓ Handles malformed response without jq"
-test_uses_correct_model_from_config && echo "✓ Uses correct model from config"
-test_uses_correct_url_from_config && echo "✓ Uses correct URL from config"
-test_removes_trailing_newlines_from_response && echo "✓ Removes trailing newlines from response"
-test_escapes_quotes_in_query && echo "✓ Escapes quotes in query"
-test_includes_context_in_api_call && echo "✓ Includes context in API call"
-test_sets_correct_temperature_option && echo "✓ Sets correct temperature option"
-test_handles_response_with_escaped_newline_with_jq && echo "✓ Handles response with escaped newline (with jq)"
-test_handles_response_with_escaped_newline_without_jq && echo "✓ Handles response with escaped newline (without jq)"
-test_handles_midfield_newline_without_jq && echo "✓ Handles mid-field newline without jq"
-test_handles_thinking_model_response && echo "✓ Handles thinking model response"
+run_test "Check if Ollama is running - success" test_check_ollama_running_success
+run_test "Check if Ollama is running - failure" test_check_ollama_running_failure
+run_test "Successful API call with jq available" test_successful_api_call_with_jq
+run_test "Successful API call without jq" test_successful_api_call_without_jq
+run_test "Handles API error response with jq" test_handles_api_error_response_with_jq
+run_test "Handles curl connection failure" test_handles_curl_connection_failure
+run_test "Handles empty response with jq" test_handles_empty_response_with_jq
+run_test "Handles malformed response without jq" test_handles_malformed_response_without_jq
+run_test "Uses correct model from config" test_uses_correct_model_from_config
+run_test "Uses correct URL from config" test_uses_correct_url_from_config
+run_test "Removes trailing newlines from response" test_removes_trailing_newlines_from_response
+run_test "Escapes quotes in query" test_escapes_quotes_in_query
+run_test "Includes context in API call" test_includes_context_in_api_call
+run_test "Sets correct temperature option" test_sets_correct_temperature_option
+run_test "Handles response with escaped newline (with jq)" test_handles_response_with_escaped_newline_with_jq
+run_test "Handles response with escaped newline (without jq)" test_handles_response_with_escaped_newline_without_jq
+run_test "Handles mid-field newline without jq" test_handles_midfield_newline_without_jq
+run_test "Handles thinking model response" test_handles_thinking_model_response
+finish_tests

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -207,27 +207,22 @@ test_includes_temperature_for_gpt4_models() {
     assert_contains "$captured_payload" '"temperature": 0.3'
 }
 
-# Add missing assert_not_empty function
-assert_not_empty() {
-    [[ -n "$1" ]]
-}
-
 # Run tests
 echo "Running OpenAI provider tests..."
-test_openai_query_success && echo "✓ OpenAI query success"
-test_openai_query_error_response && echo "✓ OpenAI error response handling"
-test_openai_json_escaping && echo "✓ OpenAI JSON escaping"
-test_handles_response_with_newline && echo "✓ Handles response with trailing newline"
-test_handles_response_without_jq && echo "✓ Handles response without jq and with newline"
-test_uses_default_url_when_not_configured && echo "✓ Uses default URL when not configured"
-test_uses_custom_url_when_configured && echo "✓ Uses custom URL when configured"
-test_uses_perplexity_url && echo "✓ Uses Perplexity URL"
-test_uses_max_tokens_for_gpt4_models && echo "✓ Uses max_tokens for gpt-4 models"
-test_uses_max_tokens_for_gpt35_models && echo "✓ Uses max_tokens for gpt-3.5 models"
-test_uses_max_completion_tokens_for_gpt5_models && echo "✓ Uses max_completion_tokens for gpt-5 models"
-test_uses_max_completion_tokens_for_o1_models && echo "✓ Uses max_completion_tokens for o1 models"
-test_omits_temperature_for_gpt5_models && echo "✓ Omits temperature for gpt-5 models"
-test_includes_temperature_for_gpt4_models && echo "✓ Includes temperature for gpt-4 models"
+run_test "OpenAI query success" test_openai_query_success
+run_test "OpenAI error response handling" test_openai_query_error_response
+run_test "OpenAI JSON escaping" test_openai_json_escaping
+run_test "Handles response with trailing newline" test_handles_response_with_newline
+run_test "Handles response without jq and with newline" test_handles_response_without_jq
+run_test "Uses default URL when not configured" test_uses_default_url_when_not_configured
+run_test "Uses custom URL when configured" test_uses_custom_url_when_configured
+run_test "Uses Perplexity URL" test_uses_perplexity_url
+run_test "Uses max_tokens for gpt-4 models" test_uses_max_tokens_for_gpt4_models
+run_test "Uses max_tokens for gpt-3.5 models" test_uses_max_tokens_for_gpt35_models
+run_test "Uses max_completion_tokens for gpt-5 models" test_uses_max_completion_tokens_for_gpt5_models
+run_test "Uses max_completion_tokens for o1 models" test_uses_max_completion_tokens_for_o1_models
+run_test "Omits temperature for gpt-5 models" test_omits_temperature_for_gpt5_models
+run_test "Includes temperature for gpt-4 models" test_includes_temperature_for_gpt4_models
 
 # Tests for keyless OpenAI-compatible endpoints
 echo ""
@@ -397,10 +392,11 @@ test_openai_falls_back_to_openai_api_key() {
     return 0
 }
 
-test_openai_requires_key_for_default_url && echo "✓ Requires API key for default OpenAI URL"
-test_openai_works_without_key_for_custom_url && echo "✓ Works without API key for custom URL"
-test_openai_query_without_auth_header && echo "✓ Omits Authorization header when no API key"
-test_openai_query_with_auth_header_when_key_set && echo "✓ Includes Authorization header when API key is set"
-test_openai_zsh_ai_key_passes_validation_for_default_url && echo "✓ ZSH_AI_OPENAI_API_KEY passes validation for default URL"
-test_openai_zsh_ai_key_takes_precedence && echo "✓ ZSH_AI_OPENAI_API_KEY takes precedence over OPENAI_API_KEY"
-test_openai_falls_back_to_openai_api_key && echo "✓ Falls back to OPENAI_API_KEY when ZSH_AI_OPENAI_API_KEY is not set"
+run_test "Requires API key for default OpenAI URL" test_openai_requires_key_for_default_url
+run_test "Works without API key for custom URL" test_openai_works_without_key_for_custom_url
+run_test "Omits Authorization header when no API key" test_openai_query_without_auth_header
+run_test "Includes Authorization header when API key is set" test_openai_query_with_auth_header_when_key_set
+run_test "ZSH_AI_OPENAI_API_KEY passes validation for default URL" test_openai_zsh_ai_key_passes_validation_for_default_url
+run_test "ZSH_AI_OPENAI_API_KEY takes precedence over OPENAI_API_KEY" test_openai_zsh_ai_key_takes_precedence
+run_test "Falls back to OPENAI_API_KEY when ZSH_AI_OPENAI_API_KEY is not set" test_openai_falls_back_to_openai_api_key
+finish_tests

--- a/tests/providers/qwen.test.zsh
+++ b/tests/providers/qwen.test.zsh
@@ -215,23 +215,19 @@ test_qwen_validation_succeeds_with_api_key() {
     assert_equals "$exit_code" "0" || return 1
 }
 
-# Add missing assert_not_empty function
-assert_not_empty() {
-    [[ -n "$1" ]]
-}
-
 # Run tests
 echo "Running Qwen provider tests..."
-test_qwen_query_success && echo "✓ Qwen query success"
-test_qwen_query_error_response && echo "✓ Qwen error response handling"
-test_qwen_json_escaping && echo "✓ Qwen JSON escaping"
-test_handles_response_with_newline && echo "✓ Handles response with trailing newline"
-test_handles_response_without_jq && echo "✓ Handles response without jq and with newline"
-test_uses_configurable_api_url && echo "✓ Uses configurable API URL (ZSH_AI_QWEN_URL)"
-test_uses_max_tokens && echo "✓ Uses max_tokens parameter"
-test_uses_qwen_api_key && echo "✓ Uses QWEN_API_KEY environment variable"
+run_test "Qwen query success" test_qwen_query_success
+run_test "Qwen error response handling" test_qwen_query_error_response
+run_test "Qwen JSON escaping" test_qwen_json_escaping
+run_test "Handles response with trailing newline" test_handles_response_with_newline
+run_test "Handles response without jq and with newline" test_handles_response_without_jq
+run_test "Uses configurable API URL (ZSH_AI_QWEN_URL)" test_uses_configurable_api_url
+run_test "Uses max_tokens parameter" test_uses_max_tokens
+run_test "Uses QWEN_API_KEY environment variable" test_uses_qwen_api_key
 
 echo ""
 echo "Running Qwen config validation tests..."
-test_qwen_requires_api_key && echo "✓ Requires API key for qwen provider"
-test_qwen_validation_succeeds_with_api_key && echo "✓ Validation succeeds with QWEN_API_KEY"
+run_test "Requires API key for qwen provider" test_qwen_requires_api_key
+run_test "Validation succeeds with QWEN_API_KEY" test_qwen_validation_succeeds_with_api_key
+finish_tests

--- a/tests/test_helper.zsh
+++ b/tests/test_helper.zsh
@@ -10,6 +10,32 @@ typeset -gA MOCKED_COMMANDS
 typeset -gA MOCK_OUTPUTS
 typeset -gA MOCK_EXIT_CODES
 typeset -gA CALL_COUNTS
+typeset -gi TEST_FAILED=0
+typeset -gi TEST_FILE_FAILED=0
+
+# Run one test and report the result.
+run_test() {
+    local test_name="$1"
+    local test_func="$2"
+    shift 2
+
+    TEST_FAILED=0
+    "$test_func" "$@"
+    local exit_code=$?
+
+    if [[ $exit_code -eq 0 && $TEST_FAILED -eq 0 ]]; then
+        echo "✓ $test_name"
+        return 0
+    fi
+
+    echo "✗ $test_name"
+    TEST_FILE_FAILED=1
+    return 1
+}
+
+finish_tests() {
+    return $TEST_FILE_FAILED
+}
 
 # Initialize mock for a command
 mock_command() {
@@ -27,7 +53,7 @@ mock_command() {
     $cmd() {
         CALL_COUNTS[$cmd]=\$((CALL_COUNTS[$cmd] + 1))
         if [[ -n \"\${MOCK_OUTPUTS[$cmd]}\" ]]; then
-            echo \"\${MOCK_OUTPUTS[$cmd]}\"
+            printf \"%s\\n\" \"\${MOCK_OUTPUTS[$cmd]}\"
         fi
         return \${MOCK_EXIT_CODES[$cmd]}
     }
@@ -59,6 +85,7 @@ assert_called() {
     
     if [[ $actual_times -ne $expected_times ]]; then
         echo "Expected $cmd to be called $expected_times times, but was called $actual_times times"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -77,7 +104,7 @@ mock_curl_response() {
         if [[ "$MOCK_CURL_EXIT_CODE" -ne 0 ]]; then
             return "$MOCK_CURL_EXIT_CODE"
         fi
-        echo "$MOCK_CURL_RESPONSE"
+        printf "%s" "$MOCK_CURL_RESPONSE"
         return 0
     }
 }
@@ -109,25 +136,29 @@ mock_jq() {
             local result=""
             if [[ "$args" == *".content[0].text"* ]]; then
                 # For Anthropic responses
-                result=$(echo "$input" | sed -n 's/.*"text":"\([^"]*\(\\.[^"]*\)*\)".*/\1/p' | sed 's/\\"/"/g')
+                result=$(printf "%s" "$input" | sed -n 's/.*"text":"\([^"]*\(\\.[^"]*\)*\)".*/\1/p' | sed 's/\\"/"/g')
             elif [[ "$args" == *".error.message"* ]]; then
                 # For error responses
-                result=$(echo "$input" | sed -n 's/.*"message":"\([^"]*\(\\.[^"]*\)*\)".*/\1/p' | sed 's/\\"/"/g')
+                result=$(printf "%s" "$input" | sed -n 's/.*"message":"\([^"]*\(\\.[^"]*\)*\)".*/\1/p' | sed 's/\\"/"/g')
             elif [[ "$args" == *".error"* ]]; then
                 # For Ollama error responses
-                result=$(echo "$input" | sed -n 's/.*"error":"\([^"]*\(\\.[^"]*\)*\)".*/\1/p' | sed 's/\\"/"/g')
+                result=$(printf "%s" "$input" | sed -n 's/.*"error":"\([^"]*\(\\.[^"]*\)*\)".*/\1/p' | sed 's/\\"/"/g')
             elif [[ "$args" == *".response"* ]]; then
                 # For Ollama responses - handle escaped quotes and newlines
                 # First extract the value, then unescape
-                result=$(echo "$input" | perl -0777 -ne 'if (/"response":\s*"([^"\\]*(\\.[^"\\]*)*)"/) { $val = $1; $val =~ s/\\n/\n/g; $val =~ s/\\"/"/g; print $val; }')
+                result=$(printf "%s" "$input" | perl -0777 -ne 'if (/"response":\s*"([^"\\]*(\\.[^"\\]*)*)"/) { $val = $1; $val =~ s/\\n/\n/g; $val =~ s/\\"/"/g; print $val; }')
             elif [[ "$args" == *".candidates[0].content.parts[0].text"* ]]; then
                 # For Gemini responses
-                result=$(echo "$input" | grep -o '"text":"[^"]*"' | head -1 | sed 's/"text":"\([^"]*\)"/\1/')
+                result=$(printf "%s" "$input" | grep -o '"text":"[^"]*"' | head -1 | sed 's/"text":"\([^"]*\)"/\1/')
+            elif [[ "$args" == *".choices[0].message.content"* ]]; then
+                # For OpenAI-compatible responses
+                result=$(printf "%s" "$input" | sed -n 's/.*"content":"\([^"]*\(\\.[^"]*\)*\)".*/\1/p' | sed 's/\\"/"/g')
             fi
             
             # Return result or empty based on // empty handling
             if [[ -n "$result" ]]; then
-                echo "$result"
+                result=$(printf "%s" "$result" | sed 's/\\n/\n/g; s/\\t/\t/g; s/\\r/\r/g; s/\\"/"/g; s/\\\\/\\/g')
+                printf "%s\n" "$result"
             elif [[ "$args" == *"// empty"* ]]; then
                 # jq returns nothing for empty
                 return 0
@@ -175,6 +206,7 @@ assert_contains() {
     local needle="$2"
     if [[ ! "$haystack" == *"$needle"* ]]; then
         echo "Expected '$haystack' to contain '$needle'"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -185,6 +217,7 @@ assert_equals() {
     local expected="$2"
     if [[ "$actual" != "$expected" ]]; then
         echo "Expected '$expected' but got '$actual'"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -195,6 +228,7 @@ assert_not_contains() {
     local needle="$2"
     if [[ "$haystack" == *"$needle"* ]]; then
         echo "Expected '$haystack' to not contain '$needle'"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -205,6 +239,17 @@ assert_greater_than() {
     local expected="$2"
     if [[ "$actual" -le "$expected" ]]; then
         echo "Expected '$actual' to be greater than '$expected'"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+# Assert string is not empty
+assert_not_empty() {
+    local value="$1"
+    if [[ -z "$value" ]]; then
+        echo "Expected value to not be empty"
+        TEST_FAILED=1
         return 1
     fi
 }

--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -246,8 +246,8 @@ test_puts_generated_command_in_buffer() {
     export ZSH_AI_PROVIDER="anthropic"
     export ANTHROPIC_API_KEY="test-key"
     
-    # Mock query function
-    _zsh_ai_query() {
+    # Mock execute command function
+    _zsh_ai_execute_command() {
         echo "ls -la"
     }
     
@@ -274,8 +274,8 @@ test_no_execution_happens() {
     export ZSH_AI_PROVIDER="anthropic"
     export ANTHROPIC_API_KEY="test-key"
     
-    # Mock query function
-    _zsh_ai_query() {
+    # Mock execute command function
+    _zsh_ai_execute_command() {
         echo "pwd"
     }
     
@@ -310,8 +310,8 @@ test_shows_loading_spinner() {
     export ZSH_AI_PROVIDER="anthropic"
     export ANTHROPIC_API_KEY="test-key"
     
-    # Mock query function with delay to simulate API call
-    _zsh_ai_query() {
+    # Mock execute command function with delay to simulate API call
+    _zsh_ai_execute_command() {
         sleep 0.3
         echo "ls -la"
     }
@@ -358,7 +358,7 @@ test_get_system_prompt_includes_all_rules() {
 test_get_system_prompt_with_complex_context() {
     setup_test_env
     
-    local complex_context="Current dir: /home/user\nGit branch: main\nProject: Node.js"
+    local complex_context=$'Current dir: /home/user\nGit branch: main\nProject: Node.js'
     local prompt=$(_zsh_ai_get_system_prompt "$complex_context")
     
     # Check that context is included at the end
@@ -374,7 +374,7 @@ test_get_system_prompt_with_empty_context() {
     local prompt=$(_zsh_ai_get_system_prompt "")
     
     # Should still include the Context: header even if empty
-    assert_contains "$prompt" "Context:\n"
+    assert_contains "$prompt" "Context:"
     
     teardown_test_env
 }
@@ -427,7 +427,7 @@ test_get_system_prompt_without_extension() {
     assert_contains "$prompt" "test context"
     
     # Should not have extra newlines where extension would be
-    local expected_pattern="glob patterns in quotes)\n\nContext:"
+    local expected_pattern=$'glob patterns in quotes)\n\nContext:'
     assert_contains "$prompt" "$expected_pattern"
     
     teardown_test_env
@@ -469,23 +469,24 @@ test_get_system_prompt_with_empty_extension() {
 
 # Run tests
 echo "Running utils tests..."
-test_routes_to_anthropic_provider && echo "✓ Routes to Anthropic provider when configured"
-test_routes_to_ollama_provider && echo "✓ Routes to Ollama provider when configured"
-test_checks_ollama_availability_before_querying && echo "✓ Checks Ollama availability before querying"
-test_shows_usage_without_arguments && echo "✓ Shows usage when called without arguments"
-test_shows_ollama_model_in_usage && echo "✓ Shows Ollama model in usage for Ollama provider"
-test_shows_command_without_executing && echo "✓ Shows command without executing"
-test_puts_command_in_buffer && echo "✓ Puts command in buffer"
-test_handles_api_errors_in_zsh_ai && echo "✓ Handles API errors in zsh-ai command"
-test_handles_empty_response_in_zsh_ai && echo "✓ Handles empty response in zsh-ai command"
-test_combines_multiple_arguments && echo "✓ Combines multiple arguments in zsh-ai command"
-test_puts_generated_command_in_buffer && echo "✓ Puts generated command in buffer"
-test_no_execution_happens && echo "✓ No execution happens"
-test_shows_loading_spinner && echo "✓ Shows loading spinner during command generation"
-test_get_system_prompt_includes_all_rules && echo "✓ System prompt includes all rules"
-test_get_system_prompt_with_complex_context && echo "✓ System prompt handles complex context"
-test_get_system_prompt_with_empty_context && echo "✓ System prompt handles empty context"
-test_get_system_prompt_with_extension && echo "✓ System prompt includes custom extension when set"
-test_get_system_prompt_without_extension && echo "✓ System prompt works without extension"
-test_get_system_prompt_with_multiline_extension && echo "✓ System prompt handles multiline extension"
-test_get_system_prompt_with_empty_extension && echo "✓ System prompt handles empty extension"
+run_test "Routes to Anthropic provider when configured" test_routes_to_anthropic_provider
+run_test "Routes to Ollama provider when configured" test_routes_to_ollama_provider
+run_test "Checks Ollama availability before querying" test_checks_ollama_availability_before_querying
+run_test "Shows usage when called without arguments" test_shows_usage_without_arguments
+run_test "Shows Ollama model in usage for Ollama provider" test_shows_ollama_model_in_usage
+run_test "Shows command without executing" test_shows_command_without_executing
+run_test "Puts command in buffer" test_puts_command_in_buffer
+run_test "Handles API errors in zsh-ai command" test_handles_api_errors_in_zsh_ai
+run_test "Handles empty response in zsh-ai command" test_handles_empty_response_in_zsh_ai
+run_test "Combines multiple arguments in zsh-ai command" test_combines_multiple_arguments
+run_test "Puts generated command in buffer" test_puts_generated_command_in_buffer
+run_test "No execution happens" test_no_execution_happens
+run_test "Shows loading spinner during command generation" test_shows_loading_spinner
+run_test "System prompt includes all rules" test_get_system_prompt_includes_all_rules
+run_test "System prompt handles complex context" test_get_system_prompt_with_complex_context
+run_test "System prompt handles empty context" test_get_system_prompt_with_empty_context
+run_test "System prompt includes custom extension when set" test_get_system_prompt_with_extension
+run_test "System prompt works without extension" test_get_system_prompt_without_extension
+run_test "System prompt handles multiline extension" test_get_system_prompt_with_multiline_extension
+run_test "System prompt handles empty extension" test_get_system_prompt_with_empty_extension
+finish_tests

--- a/tests/widget.test.zsh
+++ b/tests/widget.test.zsh
@@ -204,8 +204,8 @@ test_handles_api_errors_gracefully() {
     
     _zsh_ai_accept_line
     
-    # Buffer should be cleared on error
-    assert_equals "$BUFFER" ""
+    # Buffer should be restored on error so the user can edit the query
+    assert_equals "$BUFFER" "# invalid query"
     assert_contains "$printed_output" "Failed to generate command"
     assert_contains "$printed_output" "API connection failed"
     
@@ -342,8 +342,8 @@ test_handles_empty_api_response() {
     
     _zsh_ai_accept_line
     
-    # Buffer should be cleared
-    assert_equals "$BUFFER" ""
+    # Buffer should be restored on error so the user can edit the query
+    assert_equals "$BUFFER" "# empty response"
     assert_contains "$printed_output" "Failed to generate command"
     
     teardown_test_env
@@ -354,20 +354,15 @@ test_uses_temporary_file_for_api_response() {
     export ZSH_AI_PROVIDER="anthropic"
     export ANTHROPIC_API_KEY="test-key"
     
-    # Track mktemp calls
-    local mktemp_called=0
+    # Return a predictable temp path
     local temp_file="/tmp/test.tmp"
     mktemp() {
-        mktemp_called=1
         echo "$temp_file"
     }
     
     # Mock cat and rm
     mock_command "cat" "echo 'Hello World'" 0
-    local rm_called=0
-    rm() {
-        rm_called=1
-    }
+    mock_command "rm" "" 0
     
     # Mock the query function
     _zsh_ai_query() {
@@ -389,8 +384,7 @@ test_uses_temporary_file_for_api_response() {
     
     _zsh_ai_accept_line
     
-    assert_equals "$mktemp_called" "1"
-    assert_equals "$rm_called" "1"
+    assert_called "rm" "1"
     
     teardown_test_env
 }
@@ -434,14 +428,15 @@ test_handles_commands_with_special_characters() {
 
 # Run tests
 echo "Running widget tests..."
-test_widget_initialization_registers_precmd_hook && echo "✓ Widget initialization registers precmd hook"
-test_widget_init_hook_registers_widget_and_removes_itself && echo "✓ Widget init hook registers widget and removes itself"
-test_normal_commands_execute_without_ai_processing && echo "✓ Normal commands execute without AI processing"
-test_multiline_ai_commands_execute_without_processing && echo "✓ Multiline AI commands execute without processing"
-test_ai_commands_starting_with_hash_are_processed && echo "✓ AI commands starting with # are processed"
-test_handles_api_errors_gracefully && echo "✓ Handles API errors gracefully"
-test_shows_loading_animation_during_api_call && echo "✓ Shows loading animation during API call"
-test_preserves_original_buffer_during_animation && echo "✓ Preserves original buffer during animation"
-test_handles_empty_api_response && echo "✓ Handles empty API response"
-test_uses_temporary_file_for_api_response && echo "✓ Uses temporary file for API response"
-test_handles_commands_with_special_characters && echo "✓ Handles commands with special characters"
+run_test "Widget initialization registers precmd hook" test_widget_initialization_registers_precmd_hook
+run_test "Widget init hook registers widget and removes itself" test_widget_init_hook_registers_widget_and_removes_itself
+run_test "Normal commands execute without AI processing" test_normal_commands_execute_without_ai_processing
+run_test "Multiline AI commands execute without processing" test_multiline_ai_commands_execute_without_processing
+run_test "AI commands starting with # are processed" test_ai_commands_starting_with_hash_are_processed
+run_test "Handles API errors gracefully" test_handles_api_errors_gracefully
+run_test "Shows loading animation during API call" test_shows_loading_animation_during_api_call
+run_test "Preserves original buffer during animation" test_preserves_original_buffer_during_animation
+run_test "Handles empty API response" test_handles_empty_api_response
+run_test "Uses temporary file for API response" test_uses_temporary_file_for_api_response
+run_test "Handles commands with special characters" test_handles_commands_with_special_characters
+finish_tests


### PR DESCRIPTION
Tests were printing failed assertions while still exiting green, so regressions could slip through.

- Add shared test runner state that marks assertion failures and exits nonzero.
- Convert test files and docs to the shared runner.
- Fix widget async handling exposed by the stricter tests.
