### PR TITLE
Fix provider context escaping

### DIFF
--- a/lib/providers/anthropic.zsh
+++ b/lib/providers/anthropic.zsh
@@ -9,8 +9,7 @@ _zsh_ai_query_anthropic() {
     
     # Build context
     local context=$(_zsh_ai_build_context)
-    local escaped_context=$(_zsh_ai_escape_json "$context")
-    local system_prompt=$(_zsh_ai_get_system_prompt "$escaped_context")
+    local system_prompt=$(_zsh_ai_get_system_prompt "$context")
     local escaped_system_prompt=$(_zsh_ai_escape_json "$system_prompt")
     
     # Prepare the JSON payload - escape quotes in the query

--- a/lib/providers/gemini.zsh
+++ b/lib/providers/gemini.zsh
@@ -9,8 +9,7 @@ _zsh_ai_query_gemini() {
     
     # Build context
     local context=$(_zsh_ai_build_context)
-    local escaped_context=$(_zsh_ai_escape_json "$context")
-    local system_prompt=$(_zsh_ai_get_system_prompt "$escaped_context")
+    local system_prompt=$(_zsh_ai_get_system_prompt "$context")
     local escaped_system_prompt=$(_zsh_ai_escape_json "$system_prompt")
     
     # Prepare the JSON payload - escape quotes in the query

--- a/lib/providers/grok.zsh
+++ b/lib/providers/grok.zsh
@@ -9,8 +9,7 @@ _zsh_ai_query_grok() {
 
     # Build context
     local context=$(_zsh_ai_build_context)
-    local escaped_context=$(_zsh_ai_escape_json "$context")
-    local system_prompt=$(_zsh_ai_get_system_prompt "$escaped_context")
+    local system_prompt=$(_zsh_ai_get_system_prompt "$context")
     local escaped_system_prompt=$(_zsh_ai_escape_json "$system_prompt")
 
     # Prepare the JSON payload - escape quotes in the query

--- a/lib/providers/mistral.zsh
+++ b/lib/providers/mistral.zsh
@@ -9,8 +9,7 @@ _zsh_ai_query_mistral() {
     
     # Build context
     local context=$(_zsh_ai_build_context)
-    local escaped_context=$(_zsh_ai_escape_json "$context")
-    local system_prompt=$(_zsh_ai_get_system_prompt "$escaped_context")
+    local system_prompt=$(_zsh_ai_get_system_prompt "$context")
     local escaped_system_prompt=$(_zsh_ai_escape_json "$system_prompt")
     
     # Prepare the JSON payload - escape quotes in the query

--- a/lib/providers/ollama.zsh
+++ b/lib/providers/ollama.zsh
@@ -15,8 +15,7 @@ _zsh_ai_query_ollama() {
     
     # Build context
     local context=$(_zsh_ai_build_context)
-    local escaped_context=$(_zsh_ai_escape_json "$context")
-    local system_prompt=$(_zsh_ai_get_system_prompt "$escaped_context")
+    local system_prompt=$(_zsh_ai_get_system_prompt "$context")
     local escaped_system_prompt=$(_zsh_ai_escape_json "$system_prompt")
     
     # Prepare the JSON payload

--- a/lib/providers/openai.zsh
+++ b/lib/providers/openai.zsh
@@ -16,8 +16,7 @@ _zsh_ai_query_openai() {
     
     # Build context
     local context=$(_zsh_ai_build_context)
-    local escaped_context=$(_zsh_ai_escape_json "$context")
-    local system_prompt=$(_zsh_ai_get_system_prompt "$escaped_context")
+    local system_prompt=$(_zsh_ai_get_system_prompt "$context")
     local escaped_system_prompt=$(_zsh_ai_escape_json "$system_prompt")
     
     # Prepare the JSON payload - escape quotes in the query

--- a/lib/providers/qwen.zsh
+++ b/lib/providers/qwen.zsh
@@ -9,8 +9,7 @@ _zsh_ai_query_qwen() {
     
     # Build context
     local context=$(_zsh_ai_build_context)
-    local escaped_context=$(_zsh_ai_escape_json "$context")
-    local system_prompt=$(_zsh_ai_get_system_prompt "$escaped_context")
+    local system_prompt=$(_zsh_ai_get_system_prompt "$context")
     local escaped_system_prompt=$(_zsh_ai_escape_json "$system_prompt")
     
     # Prepare the JSON payload - escape quotes in the query

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -5,13 +5,26 @@
 # Function to get the standardized system prompt for all providers
 _zsh_ai_get_system_prompt() {
     local context="$1"
-    local base_prompt="You are a zsh command generator. Generate syntactically correct zsh commands based on the user's natural language request.\n\nIMPORTANT RULES:\n1. Output ONLY the raw command - no explanations, no markdown, no backticks\n2. For arguments containing spaces or special characters, use single quotes\n3. Use double quotes only when variable expansion is needed\n4. Properly escape special characters within quotes\n\nExamples:\n- echo 'Hello World!' (spaces require quotes)\n- echo \"Current user: \$USER\" (variable expansion needs double quotes)\n- grep 'pattern with spaces' file.txt\n- find . -name '*.txt' (glob patterns in quotes)"
+    local base_prompt="You are a zsh command generator. Generate syntactically correct zsh commands based on the user's natural language request.
+
+IMPORTANT RULES:
+1. Output ONLY the raw command - no explanations, no markdown, no backticks
+2. For arguments containing spaces or special characters, use single quotes
+3. Use double quotes only when variable expansion is needed
+4. Properly escape special characters within quotes
+
+Examples:
+- echo 'Hello World!' (spaces require quotes)
+- echo \"Current user: \$USER\" (variable expansion needs double quotes)
+- grep 'pattern with spaces' file.txt
+- find . -name '*.txt' (glob patterns in quotes)"
     
     # Add custom prompt extension if provided
     if [[ -n "$ZSH_AI_PROMPT_EXTEND" ]]; then
-        echo "${base_prompt}\n\n${ZSH_AI_PROMPT_EXTEND}\n\nContext:\n$context"
+        local prompt_extend="${ZSH_AI_PROMPT_EXTEND//\\n/$'\n'}"
+        printf '%s\n\n%s\n\nContext:\n%s\n' "$base_prompt" "$prompt_extend" "$context"
     else
-        echo "${base_prompt}\n\nContext:\n$context"
+        printf '%s\n\nContext:\n%s\n' "$base_prompt" "$context"
     fi
 }
 

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -21,7 +21,8 @@ Examples:
     
     # Add custom prompt extension if provided
     if [[ -n "$ZSH_AI_PROMPT_EXTEND" ]]; then
-        local prompt_extend="${ZSH_AI_PROMPT_EXTEND//\\n/$'\n'}"
+        local newline=$'\n'
+        local prompt_extend="${ZSH_AI_PROMPT_EXTEND//\\n/$newline}"
         printf '%s\n\n%s\n\nContext:\n%s\n' "$base_prompt" "$prompt_extend" "$context"
     else
         printf '%s\n\nContext:\n%s\n' "$base_prompt" "$context"

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -71,6 +71,57 @@ test_openai_json_escaping() {
     assert_not_empty "$result"
 }
 
+test_builds_system_prompt_from_raw_context() {
+    export OPENAI_API_KEY="test-key"
+    export ZSH_AI_OPENAI_MODEL="gpt-4o-mini"
+    export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
+    local payload_file=$(mktemp)
+
+    _zsh_ai_build_context() {
+        printf '%s\n%s' 'Current directory: /tmp/"quoted"' 'Files: slash\path.txt'
+    }
+
+    curl() {
+        if [[ "$*" == *"https://api.openai.com/v1/chat/completions"* ]]; then
+            local prev_arg=""
+            for arg in "$@"; do
+                if [[ "$prev_arg" == "--data" ]]; then
+                    printf '%s' "$arg" > "$payload_file"
+                    break
+                fi
+                prev_arg="$arg"
+            done
+            echo '{"choices":[{"message":{"content":"test"}}]}'
+            return 0
+        fi
+        command curl "$@"
+    }
+
+    _zsh_ai_query_openai "test" >/dev/null
+    local captured_payload=$(cat "$payload_file")
+    rm -f "$payload_file"
+
+    # Restore the real context builder for the rest of the file.
+    source "${PLUGIN_DIR}/lib/context.zsh"
+
+    local decoded_system_prompt=$(printf "%s" "$captured_payload" | perl -MJSON::PP -0777 -ne 'print decode_json($_)->{messages}->[0]->{content}')
+
+    assert_contains "$decoded_system_prompt" 'Current directory: /tmp/"quoted"'
+
+    if ! printf '%s' "$decoded_system_prompt" | grep -Fq 'Files: slash\path.txt'; then
+        printf '%s\n' "Expected decoded system prompt to contain literal backslash context"
+        TEST_FAILED=1
+    fi
+    if printf '%s' "$decoded_system_prompt" | grep -Fq '\"quoted\"'; then
+        printf '%s\n' "Expected decoded system prompt to contain raw quotes, not escaped quotes"
+        TEST_FAILED=1
+    fi
+    if printf '%s' "$decoded_system_prompt" | grep -Fq 'slash\\path.txt'; then
+        printf '%s\n' "Expected decoded system prompt to contain one backslash, not two"
+        TEST_FAILED=1
+    fi
+}
+
 test_handles_response_with_newline() {
     export OPENAI_API_KEY="test-key"
     export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
@@ -160,7 +211,7 @@ capture_openai_payload_for_model() {
             local prev_arg=""
             for arg in "$@"; do
                 if [[ "$prev_arg" == "--data" ]]; then
-                    echo "$arg" > "$payload_file"
+                    printf '%s' "$arg" > "$payload_file"
                     break
                 fi
                 prev_arg="$arg"
@@ -212,6 +263,7 @@ echo "Running OpenAI provider tests..."
 run_test "OpenAI query success" test_openai_query_success
 run_test "OpenAI error response handling" test_openai_query_error_response
 run_test "OpenAI JSON escaping" test_openai_json_escaping
+run_test "Builds system prompt from raw context" test_builds_system_prompt_from_raw_context
 run_test "Handles response with trailing newline" test_handles_response_with_newline
 run_test "Handles response without jq and with newline" test_handles_response_without_jq
 run_test "Uses default URL when not configured" test_uses_default_url_when_not_configured

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -78,7 +78,7 @@ test_builds_system_prompt_from_raw_context() {
     local payload_file=$(mktemp)
 
     _zsh_ai_build_context() {
-        printf '%s\n%s' 'Current directory: /tmp/"quoted"' 'Files: slash\path.txt'
+        printf '%s\n%s' 'Current directory: /tmp/"quoted"' 'Files: a\b.txt'
     }
 
     curl() {
@@ -108,7 +108,7 @@ test_builds_system_prompt_from_raw_context() {
 
     assert_contains "$decoded_system_prompt" 'Current directory: /tmp/"quoted"'
 
-    if ! printf '%s' "$decoded_system_prompt" | grep -Fq 'Files: slash\path.txt'; then
+    if ! printf '%s' "$decoded_system_prompt" | grep -Fq 'Files: a\b.txt'; then
         printf '%s\n' "Expected decoded system prompt to contain literal backslash context"
         TEST_FAILED=1
     fi
@@ -116,7 +116,7 @@ test_builds_system_prompt_from_raw_context() {
         printf '%s\n' "Expected decoded system prompt to contain raw quotes, not escaped quotes"
         TEST_FAILED=1
     fi
-    if printf '%s' "$decoded_system_prompt" | grep -Fq 'slash\\path.txt'; then
+    if printf '%s' "$decoded_system_prompt" | grep -Fq 'a\\b.txt'; then
         printf '%s\n' "Expected decoded system prompt to contain one backslash, not two"
         TEST_FAILED=1
     fi

--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -448,15 +448,27 @@ test_get_system_prompt_with_multiline_extension() {
     setup_test_env
     
     # Set multi-line custom prompt extension
-    export ZSH_AI_PROMPT_EXTEND="Additional rules:\n1. Prefer fd over find\n2. Use bat instead of cat\n3. Always use exa for ls commands"
+    export ZSH_AI_PROMPT_EXTEND="Additional rules:\n1. Prefer fd over find\n2. Use bat instead of cat\n3. Keep a\b literal"
     
     local prompt=$(_zsh_ai_get_system_prompt "test context")
-    
-    # Check that all lines of extension are included
-    assert_contains "$prompt" "Additional rules:"
-    assert_contains "$prompt" "1. Prefer fd over find"
-    assert_contains "$prompt" "2. Use bat instead of cat"
-    assert_contains "$prompt" "3. Always use exa for ls commands"
+
+    local prompt_lines=("${(@f)prompt}")
+    local extension_start=0
+    for i in {1..${#prompt_lines[@]}}; do
+        if [[ "${prompt_lines[$i]}" == "Additional rules:" ]]; then
+            extension_start=$i
+            break
+        fi
+    done
+
+    if [[ $extension_start -eq 0 ]]; then
+        echo "Error: Prompt extension missing"
+        return 1
+    fi
+
+    assert_equals "${prompt_lines[$((extension_start + 1))]}" "1. Prefer fd over find"
+    assert_equals "${prompt_lines[$((extension_start + 2))]}" "2. Use bat instead of cat"
+    assert_equals "${prompt_lines[$((extension_start + 3))]}" '3. Keep a\b literal'
     
     teardown_test_env
 }

--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -368,6 +368,17 @@ test_get_system_prompt_with_complex_context() {
     teardown_test_env
 }
 
+test_get_system_prompt_preserves_backslash_context() {
+    setup_test_env
+
+    local prompt=$(_zsh_ai_get_system_prompt 'Files: a\b.txt')
+    local context_line=$(printf '%s' "$prompt" | tail -n 1)
+
+    assert_equals "$context_line" 'Files: a\b.txt'
+
+    teardown_test_env
+}
+
 test_get_system_prompt_with_empty_context() {
     setup_test_env
     
@@ -484,6 +495,7 @@ run_test "No execution happens" test_no_execution_happens
 run_test "Shows loading spinner during command generation" test_shows_loading_spinner
 run_test "System prompt includes all rules" test_get_system_prompt_includes_all_rules
 run_test "System prompt handles complex context" test_get_system_prompt_with_complex_context
+run_test "System prompt preserves backslash context" test_get_system_prompt_preserves_backslash_context
 run_test "System prompt handles empty context" test_get_system_prompt_with_empty_context
 run_test "System prompt includes custom extension when set" test_get_system_prompt_with_extension
 run_test "System prompt works without extension" test_get_system_prompt_without_extension


### PR DESCRIPTION
Context was being JSON-escaped before insertion into the shared system prompt, then escaped again when building each provider payload. That meant providers saw literal \" and escaped context artifacts instead of raw shell context.

- Build the system prompt from raw context, then JSON-escape the finished prompt once across all providers.
- Replace prompt construction echo with printf so raw context backslashes like a\b.txt are preserved.
- Preserve literal \n prompt extensions as real extension lines without interpreting other backslashes.
- Add regressions for decoded provider payloads, raw backslash context, and multiline prompt extension layout.

Testing:
- zsh tests/utils.test.zsh
- zsh tests/providers/openai.test.zsh
- ./run-tests.zsh
- Manual: prompt byte checks for context backslashes and ZSH_AI_PROMPT_EXTEND literal \n lines
- Manual: stubbed payload decode for anthropic, gemini, grok, mistral, ollama, openai, and qwen with quoted context, a\b.txt, and multiline prompt extension, verified context and extension bytes as 5c 62
- Manual: direct zsh-ai and widget happy paths with an OpenAI stub
- Manual: plugin load with OpenAI config