### PR TITLE
openai: add support for ZSH_AI_OPENAI_THINKING flag

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -133,6 +133,8 @@ export ZSH_AI_OPENAI_API_KEY="sk-your-proxy-key"
 
 `ZSH_AI_OPENAI_API_KEY` takes priority over `OPENAI_API_KEY`.
 
+`ZSH_AI_OPENAI_THINKING` sets the `chat_template_kwargs.enable_thinking` parameter, which is a non-standard API that controls thinking output for reasoning models with chat templates. Set to `0` to disable, `1` to enable, or leave unset for upstream defaults.
+
 ## Load zsh-ai
 
 Put the load line after your provider block in `~/.zshrc`.

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -9,6 +9,7 @@
 : ${ZSH_AI_GEMINI_MODEL:="gemini-2.5-flash"}  # Fast Gemini 2.5 model
 : ${ZSH_AI_OPENAI_MODEL:="gpt-5.4-mini"}  # Default to GPT-5.4 mini (gpt-5-mini is deprecated)
 : ${ZSH_AI_OPENAI_URL:="https://api.openai.com/v1/chat/completions"}  # Default to OpenAI
+: ${ZSH_AI_OPENAI_THINKING:=""}  # Configure thinking for supported models: 0 or 1, default unset/empty
 : ${ZSH_AI_QWEN_MODEL:="qwen-flash"}  # Default to qwen-flash (fast, low-cost Qwen3 tier)
 : ${ZSH_AI_QWEN_URL:="https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"}  # Default to Qwen API
 : ${ZSH_AI_ANTHROPIC_MODEL:="claude-haiku-4-5"}  # Default Anthropic model
@@ -60,6 +61,11 @@ _zsh_ai_validate_config() {
         if [[ -z "$OPENAI_API_KEY" && -z "$ZSH_AI_OPENAI_API_KEY" && "$ZSH_AI_OPENAI_URL" == "https://api.openai.com/v1/chat/completions" ]]; then
             echo "zsh-ai: Warning: OPENAI_API_KEY not set. Plugin will not function."
             echo "zsh-ai: Set OPENAI_API_KEY or use ZSH_AI_PROVIDER=ollama for local models."
+            return 1
+        fi
+
+        if [[ -n "$ZSH_AI_OPENAI_THINKING" && "$ZSH_AI_OPENAI_THINKING" != "0" && "$ZSH_AI_OPENAI_THINKING" != "1" ]]; then
+            echo "zsh-ai: Error: ZSH_AI_OPENAI_THINKING must be 0, 1, or unset."
             return 1
         fi
     elif [[ "$ZSH_AI_PROVIDER" == "qwen" ]]; then

--- a/lib/providers/openai.zsh
+++ b/lib/providers/openai.zsh
@@ -13,13 +13,13 @@ _zsh_ai_openai_supports_temperature() {
 _zsh_ai_query_openai() {
     local query="$1"
     local response
-    
+
     # Build context
     local context=$(_zsh_ai_build_context)
     local escaped_context=$(_zsh_ai_escape_json "$context")
     local system_prompt=$(_zsh_ai_get_system_prompt "$escaped_context")
     local escaped_system_prompt=$(_zsh_ai_escape_json "$system_prompt")
-    
+
     # Prepare the JSON payload - escape quotes in the query
     local escaped_query=$(_zsh_ai_escape_json "$query")
 
@@ -34,6 +34,13 @@ _zsh_ai_query_openai() {
         temperature_param=$',\n    "temperature": 0.3'
     fi
 
+    local thinking_param=""
+    case "$ZSH_AI_OPENAI_THINKING" in
+        "") ;; # Don't override upstream defaults when unset
+        0) thinking_param=$',\n    "chat_template_kwargs": { "enable_thinking": false }' ;;
+        1) thinking_param=$',\n    "chat_template_kwargs": { "enable_thinking": true }' ;;
+    esac
+
     local json_payload=$(cat <<EOF
 {
     "model": "${ZSH_AI_OPENAI_MODEL}",
@@ -47,11 +54,11 @@ _zsh_ai_query_openai() {
             "content": "$escaped_query"
         }
     ],
-    "$token_param": 256${temperature_param}
+    "$token_param": 256${temperature_param}${thinking_param}
 }
 EOF
 )
-    
+
     # Call the API - only add auth header if API key is set
     # ZSH_AI_OPENAI_API_KEY takes precedence (useful for LiteLLM and other proxies)
     local auth_args=()
@@ -62,15 +69,15 @@ EOF
         "${auth_args[@]}" \
         --header "content-type: application/json" \
         --data "$json_payload" 2>&1)
-    
+
     if [[ $? -ne 0 ]]; then
         echo "Error: Failed to connect to OpenAI API"
         return 1
     fi
-    
+
     # Debug: Uncomment to see raw response
     # echo "DEBUG: Raw response: $response" >&2
-    
+
     # Extract the content from the response
     # Try using jq if available, otherwise fall back to sed/grep
     if command -v jq &> /dev/null; then

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -399,4 +399,42 @@ run_test "Includes Authorization header when API key is set" test_openai_query_w
 run_test "ZSH_AI_OPENAI_API_KEY passes validation for default URL" test_openai_zsh_ai_key_passes_validation_for_default_url
 run_test "ZSH_AI_OPENAI_API_KEY takes precedence over OPENAI_API_KEY" test_openai_zsh_ai_key_takes_precedence
 run_test "Falls back to OPENAI_API_KEY when ZSH_AI_OPENAI_API_KEY is not set" test_openai_falls_back_to_openai_api_key
+
+# Tests for ZSH_AI_OPENAI_THINKING
+echo ""
+echo "Running OpenAI-compatible thinking flag tests..."
+
+test_openai_thinking_unset_omits_param() {
+    unset ZSH_AI_OPENAI_THINKING
+    local captured_payload=$(capture_openai_payload_for_model "gpt-5-mini")
+    assert_not_contains "$captured_payload" '"chat_template_kwargs"'
+}
+
+test_openai_thinking_enabled_sets_true() {
+    export ZSH_AI_OPENAI_THINKING=1
+    local captured_payload=$(capture_openai_payload_for_model "gpt-5-mini")
+    assert_contains "$captured_payload" '"enable_thinking": true'
+}
+
+test_openai_thinking_disabled_sets_false() {
+    export ZSH_AI_OPENAI_THINKING=0
+    local captured_payload=$(capture_openai_payload_for_model "gpt-5-mini")
+    assert_contains "$captured_payload" '"enable_thinking": false'
+}
+
+test_openai_thinking_invalid_value_returns_error() {
+    export ZSH_AI_OPENAI_THINKING="invalid"
+
+    local result
+    result=$(_zsh_ai_validate_config 2>&1)
+    local exit_code=$?
+
+    # Should not pass validation since it is not 0, 1, or unset
+    assert_equals "$exit_code" "1"
+}
+
+run_test "ZSH_AI_OPENAI_THINKING unset omits chat_template_kwargs parameter" test_openai_thinking_unset_omits_param
+run_test "ZSH_AI_OPENAI_THINKING=1 sets enable_thinking true" test_openai_thinking_enabled_sets_true
+run_test "ZSH_AI_OPENAI_THINKING=0 sets enable_thinking false" test_openai_thinking_disabled_sets_false
+run_test "Invalid ZSH_AI_OPENAI_THINKING value returns error" test_openai_thinking_invalid_value_returns_error
 finish_tests


### PR DESCRIPTION
Hi,

this change adds support for `ZSH_AI_OPENAI_THINKING` config which enables or disables "thinking" for reasoning models which support it. It can be set to `0`, `1`, or `undefined`. 

The undefined category allows the user not to affect the default upstream model configuration.

undefined:
```
~ $ time (unset ZSH_AI_OPENAI_THINKING && _zsh_ai_query_openai 'list files';)  
...
        {
            "role": "user",
            "content": "list files"
        }
    ],
    "max_completion_tokens": 256,
    "temperature": 0.3
}
Error: Unable to parse response
0.01s user 0.01s system 0% cpu 11.325 total
                               ^^^^^^^^^^^^
```

1:

```
~ $ time (ZSH_AI_OPENAI_THINKING=1 && _zsh_ai_query_openai 'list files';)
...
        {
            "role": "user",
            "content": "list files"
        }
    ],
    "max_completion_tokens": 256,
    "temperature": 0.3,
    "chat_template_kwargs": { "enable_thinking": true }
}
ls
0.01s user 0.01s system 0% cpu 6.306 total
                               ^^^^^^^^^^^
```

0:

```
~ $ time (ZSH_AI_OPENAI_THINKING=0 && _zsh_ai_query_openai 'list files';)
...
        {
            "role": "user",
            "content": "list files"
        }
    ],
    "max_completion_tokens": 256,
    "temperature": 0.3,
    "chat_template_kwargs": { "enable_thinking": false }
}
ls( ZSH_AI_OPENAI_THINKING=0 _zsh_ai_query_openai 'list files'; )
0.01s user 0.01s system 15% cpu 0.162 total
                                ^^^^^^^^^^^
```

As seen above the added bonus is that inference is faster in some cases, and resolves issue with `max_completion_tokens` being exhausted.