### PR TITLE
Make the inline trigger configurable and toggleable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -198,6 +198,24 @@ export ZSH_AI_QWEN_URL="https://dashscope.aliyuncs.com/compatible-mode/v1/chat/c
 export ZSH_AI_PROMPT_EXTEND="Prefer rg over grep, fd over find, and bat over cat."
 ```
 
+## Inline Trigger
+
+By default, lines starting with `# ` are sent to the AI when you press Enter. Both
+the trigger prefix and the hook itself are configurable:
+
+```bash
+# Change the trigger (default is "# "). For example, use ,, to start a query:
+export ZSH_AI_TRIGGER=",,"
+
+# Disable the inline hook entirely. Lines starting with "# " behave as normal
+# shell comments again, and only the `zsh-ai "..."` command stays active.
+# Useful when pasting code blocks that contain "# comment" lines.
+export ZSH_AI_COMMENT_HOOK="false"
+```
+
+`ZSH_AI_COMMENT_HOOK` accepts `false`, `off`, `no`, `0`, or `disabled` (case
+insensitive) to turn the hook off; any other value keeps it on.
+
 ## Requirements
 
 - zsh 5.0+

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Full setup lives in [INSTALL.md](INSTALL.md).
 
 Type `#`, describe the job, then press Enter.
 
+The trigger is configurable, and the inline hook can be turned off entirely if you
+only want the `zsh-ai "..."` command — see [Configuration](#configuration).
+
 <img src="https://github.com/user-attachments/assets/eff46629-855c-41eb-9de3-a53040bd2654" alt="zsh-ai comment syntax demo" width="520">
 
 ```bash
@@ -102,6 +105,17 @@ Add command preferences without replacing the built-in quoting rules:
 
 ```bash
 export ZSH_AI_PROMPT_EXTEND="Prefer rg over grep, fd over find, and bat over cat."
+```
+
+Change the inline trigger, or disable the comment hook altogether (handy when you
+paste code blocks that start with `#` comments):
+
+```bash
+# Use ,, instead of "# " to start a query
+export ZSH_AI_TRIGGER=",,"
+
+# Disable the inline hook entirely; only `zsh-ai "..."` stays active
+export ZSH_AI_COMMENT_HOOK="false"
 ```
 
 ## Docs

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -53,6 +53,22 @@ zsh-ai "list files"
 
 If that works, restart your terminal so the zle widget binding reloads.
 
+## Pasting Code Breaks `#` Comments
+
+If you paste code blocks that start with `# comment` lines, the inline hook can
+intercept the first line and fire an unwanted query. Either change the trigger to
+something you won't paste, or disable the hook and use `zsh-ai "..."` instead:
+
+```bash
+# Use a different trigger
+export ZSH_AI_TRIGGER=",,"
+
+# Or turn the inline hook off entirely
+export ZSH_AI_COMMENT_HOOK="false"
+```
+
+See [INSTALL.md](INSTALL.md#inline-trigger) for details.
+
 ## JSON Parse Errors
 
 Install `jq`:

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -18,6 +18,18 @@
 : ${ZSH_AI_MISTRAL_MODEL:="mistral-small-latest"}  # Default Mistral model
 : ${ZSH_AI_MISTRAL_URL:="https://api.mistral.ai/v1/chat/completions"}  # Default Mistral URL
 
+# Inline trigger configuration
+: ${ZSH_AI_COMMENT_HOOK:="true"}  # Set to false/off/no/0 to disable the inline trigger widget entirely
+: ${ZSH_AI_TRIGGER:="# "}  # Prompt prefix that triggers AI (e.g. ",," instead of "# ")
+
+# Return 0 if the inline trigger widget should be enabled, 1 otherwise
+_zsh_ai_comment_hook_enabled() {
+    case "${ZSH_AI_COMMENT_HOOK:l}" in
+        false|off|no|0|disabled) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
 # Optional: Extend the system prompt with custom instructions
 # ZSH_AI_PROMPT_EXTEND - Add custom instructions to the AI prompt without replacing the core prompt
 # Example: export ZSH_AI_PROMPT_EXTEND="Always prefer ripgrep (rg) over grep. Use modern CLI tools when available."

--- a/lib/widget.zsh
+++ b/lib/widget.zsh
@@ -4,17 +4,19 @@
 
 # Custom widget to intercept Enter key
 _zsh_ai_accept_line() {
-    # Check if the line starts with "# " and handle multiline input
-    if [[ "$BUFFER" =~ ^'# ' ]]; then
+    local trigger="${ZSH_AI_TRIGGER:-# }"
+
+    # Check if the line starts with the configured trigger and handle multiline input
+    if [[ -n "$trigger" && "$BUFFER" == "$trigger"* ]]; then
         # Check if buffer contains newlines (multiline command)
         if [[ "$BUFFER" == *$'\n'* ]]; then
             # Multiline command detected - execute normally without AI processing
             zle .accept-line
             return
         fi
-        
-        # Extract the query (remove the "# " prefix)
-        local query="${BUFFER:2}"
+
+        # Extract the query (remove the trigger prefix)
+        local query="${BUFFER#"$trigger"}"
         
         # Add a loading indicator with animation
         local saved_buffer="$BUFFER"
@@ -87,6 +89,10 @@ _zsh_ai_accept_line() {
 # Uses precmd hook to defer registration until ZLE is fully initialized
 # This fixes the issue where zle -N fails silently during plugin sourcing
 _zsh_ai_init_widget() {
+    # Respect the toggle: when disabled, never intercept accept-line so the
+    # inline trigger (default "# ") behaves like a normal shell comment.
+    _zsh_ai_comment_hook_enabled || return
+
     _zsh_ai_do_init() {
         zle -N accept-line _zsh_ai_accept_line
         add-zsh-hook -d precmd _zsh_ai_do_init

--- a/lib/widget.zsh
+++ b/lib/widget.zsh
@@ -7,7 +7,7 @@ _zsh_ai_accept_line() {
     local trigger="${ZSH_AI_TRIGGER:-# }"
 
     # Check if the line starts with the configured trigger and handle multiline input
-    if [[ -n "$trigger" && "$BUFFER" == "$trigger"* ]]; then
+    if [[ "$BUFFER" == "$trigger"* ]]; then
         # Check if buffer contains newlines (multiline command)
         if [[ "$BUFFER" == *$'\n'* ]]; then
             # Multiline command detected - execute normally without AI processing

--- a/tests/config.test.zsh
+++ b/tests/config.test.zsh
@@ -79,6 +79,36 @@ test_validates_openai_provider() {
     teardown_test_env
 }
 
+test_comment_hook_enabled_by_default() {
+    setup_test_env
+    unset ZSH_AI_COMMENT_HOOK
+    source "$PLUGIN_DIR/lib/config.zsh"
+    _zsh_ai_comment_hook_enabled
+    local result=$?
+    assert_equals "$result" "0"
+    teardown_test_env
+}
+
+test_comment_hook_can_be_disabled() {
+    setup_test_env
+    local value
+    for value in false off no 0 disabled FALSE Off; do
+        export ZSH_AI_COMMENT_HOOK="$value"
+        _zsh_ai_comment_hook_enabled
+        assert_equals "$?" "1"
+    done
+    unset ZSH_AI_COMMENT_HOOK
+    teardown_test_env
+}
+
+test_default_trigger_is_hash() {
+    setup_test_env
+    unset ZSH_AI_TRIGGER
+    source "$PLUGIN_DIR/lib/config.zsh"
+    assert_equals "$ZSH_AI_TRIGGER" "# "
+    teardown_test_env
+}
+
 # Run tests
 echo "Running config tests..."
 run_test "Default provider is anthropic" test_default_provider
@@ -89,4 +119,7 @@ run_test "Validates ollama provider" test_validates_ollama_provider
 run_test "Rejects invalid provider" test_rejects_invalid_provider
 run_test "Validates gemini provider" test_validates_gemini_provider
 run_test "Validates openai provider" test_validates_openai_provider
+run_test "Comment hook enabled by default" test_comment_hook_enabled_by_default
+run_test "Comment hook can be disabled" test_comment_hook_can_be_disabled
+run_test "Default trigger is '# '" test_default_trigger_is_hash
 finish_tests

--- a/tests/widget.test.zsh
+++ b/tests/widget.test.zsh
@@ -426,6 +426,87 @@ test_handles_commands_with_special_characters() {
     teardown_test_env
 }
 
+test_init_widget_skips_registration_when_disabled() {
+    setup_test_env
+    export ZSH_AI_PROVIDER="anthropic"
+    export ANTHROPIC_API_KEY="test-key"
+    export ZSH_AI_COMMENT_HOOK="false"
+
+    # Track add-zsh-hook calls
+    typeset -ga HOOK_CALLS
+    HOOK_CALLS=()
+    add-zsh-hook() {
+        HOOK_CALLS+=("$1:$2:$3")
+    }
+    autoload() { :; }
+
+    _zsh_ai_init_widget
+
+    # No precmd hook should have been registered
+    assert_equals "${#HOOK_CALLS[@]}" "0"
+
+    unset ZSH_AI_COMMENT_HOOK
+    teardown_test_env
+}
+
+test_custom_trigger_is_processed() {
+    setup_test_env
+    export ZSH_AI_PROVIDER="anthropic"
+    export ANTHROPIC_API_KEY="test-key"
+    export ZSH_AI_TRIGGER=",,"
+
+    # Echo back the query so we can verify the trigger prefix was stripped.
+    # The widget runs this in a background subshell and reads its stdout from a
+    # temp file, so we rely on a real temp file rather than mocking cat/mktemp.
+    _zsh_ai_execute_command() {
+        printf "query:%s" "$1"
+    }
+
+    mock_command "kill" "" 1
+
+    local RESET_PROMPT_CALLED=0
+    zle() {
+        case "$1" in
+            "reset-prompt") RESET_PROMPT_CALLED=1 ;;
+        esac
+    }
+
+    BUFFER=",,list all files"
+    CURSOR=0
+
+    _zsh_ai_accept_line
+
+    # Buffer holds the command produced from the query with the ",," stripped
+    assert_equals "$BUFFER" "query:list all files"
+    assert_equals "$RESET_PROMPT_CALLED" "1"
+
+    unset ZSH_AI_TRIGGER
+    teardown_test_env
+}
+
+test_default_hash_ignored_when_trigger_changed() {
+    setup_test_env
+    export ZSH_AI_PROVIDER="anthropic"
+    export ANTHROPIC_API_KEY="test-key"
+    export ZSH_AI_TRIGGER=",,"
+
+    local ACCEPT_LINE_CALLED=0
+    zle() {
+        case "$1" in
+            ".accept-line") ACCEPT_LINE_CALLED=1 ;;
+        esac
+    }
+
+    # With a custom trigger, a leading "# " is a normal comment, not a query
+    BUFFER="# list files"
+    _zsh_ai_accept_line
+
+    assert_equals "$ACCEPT_LINE_CALLED" "1"
+
+    unset ZSH_AI_TRIGGER
+    teardown_test_env
+}
+
 # Run tests
 echo "Running widget tests..."
 run_test "Widget initialization registers precmd hook" test_widget_initialization_registers_precmd_hook
@@ -439,4 +520,7 @@ run_test "Preserves original buffer during animation" test_preserves_original_bu
 run_test "Handles empty API response" test_handles_empty_api_response
 run_test "Uses temporary file for API response" test_uses_temporary_file_for_api_response
 run_test "Handles commands with special characters" test_handles_commands_with_special_characters
+run_test "Init widget skips registration when disabled" test_init_widget_skips_registration_when_disabled
+run_test "Custom trigger is processed" test_custom_trigger_is_processed
+run_test "Default '# ' ignored when trigger changed" test_default_hash_ignored_when_trigger_changed
 finish_tests

--- a/tests/widget.test.zsh
+++ b/tests/widget.test.zsh
@@ -503,7 +503,7 @@ test_default_hash_ignored_when_trigger_changed() {
 
     assert_equals "$ACCEPT_LINE_CALLED" "1"
 
-    unset ZSH_AI_TRIGGER
+    export ZSH_AI_TRIGGER="# "
     teardown_test_env
 }
 

--- a/tests/widget.test.zsh
+++ b/tests/widget.test.zsh
@@ -480,7 +480,7 @@ test_custom_trigger_is_processed() {
     assert_equals "$BUFFER" "query:list all files"
     assert_equals "$RESET_PROMPT_CALLED" "1"
 
-    unset ZSH_AI_TRIGGER
+    export ZSH_AI_TRIGGER="# "
     teardown_test_env
 }
 


### PR DESCRIPTION
## Problem

The `# comment` trigger fires accidental API requests when copy-pasting code blocks from AI chats that include inline comments (e.g. a block whose first line is `# Update packages`). Some users only want the manual `zsh-ai "..."` command and would like to disable the inline hook entirely. (Reported in #issue — accidental requests on paste.)

## Changes

Two new config variables, both backwards compatible (defaults preserve current behavior):

- **`ZSH_AI_COMMENT_HOOK`** (default `true`): set to `false`/`off`/`no`/`0`/`disabled` (case-insensitive) to skip binding the `accept-line` widget entirely. Lines starting with `# ` behave as normal shell comments again, and only `zsh-ai "..."` stays active.
- **`ZSH_AI_TRIGGER`** (default `"# "`): change the prompt prefix that triggers a query — e.g. `,,` instead of `# `.

```bash
# Use ,, instead of "# "
export ZSH_AI_TRIGGER=",,"

# Or turn the inline hook off entirely
export ZSH_AI_COMMENT_HOOK="false"
```

## Implementation

- `lib/config.zsh`: defaults for both vars + `_zsh_ai_comment_hook_enabled` helper.
- `lib/widget.zsh`: `_zsh_ai_init_widget` returns early when disabled; `_zsh_ai_accept_line` matches `$ZSH_AI_TRIGGER` as a literal prefix and strips it from the query.
- Docs updated in `README.md`, `INSTALL.md`, and `TROUBLESHOOTING.md`.

## Tests

Added coverage in `tests/config.test.zsh` (default value, enabled-by-default, disable values) and `tests/widget.test.zsh` (registration skipped when disabled, custom trigger processed, default `# ` ignored when trigger changed). Full suite passes:

```
Total Tests: 187
Passed: 187
Failed: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)