### PR TITLE
Update default models for OpenAI, Grok, and Qwen

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -173,12 +173,12 @@ You should see a command like `date` appear in your prompt.
 ```bash
 export ZSH_AI_PROVIDER="anthropic"
 export ZSH_AI_ANTHROPIC_MODEL="claude-haiku-4-5"
-export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
+export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
 export ZSH_AI_GEMINI_MODEL="gemini-2.5-flash"
 export ZSH_AI_OLLAMA_MODEL="llama3.2"
 export ZSH_AI_MISTRAL_MODEL="mistral-small-latest"
-export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
-export ZSH_AI_QWEN_MODEL="qwen-plus"
+export ZSH_AI_GROK_MODEL="grok-4.3"
+export ZSH_AI_QWEN_MODEL="qwen-flash"
 ```
 
 Provider URLs are configurable too:

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -7,13 +7,13 @@
 : ${ZSH_AI_OLLAMA_MODEL:="llama3.2"}  # Popular fast model
 : ${ZSH_AI_OLLAMA_URL:="http://localhost:11434"}  # Default Ollama URL
 : ${ZSH_AI_GEMINI_MODEL:="gemini-2.5-flash"}  # Fast Gemini 2.5 model
-: ${ZSH_AI_OPENAI_MODEL:="gpt-5-mini"}  # Default to GPT-5 mini
+: ${ZSH_AI_OPENAI_MODEL:="gpt-5.4-mini"}  # Default to GPT-5.4 mini (gpt-5-mini is deprecated)
 : ${ZSH_AI_OPENAI_URL:="https://api.openai.com/v1/chat/completions"}  # Default to OpenAI
-: ${ZSH_AI_QWEN_MODEL:="qwen-plus"}  # Default to qwen-plus
+: ${ZSH_AI_QWEN_MODEL:="qwen-flash"}  # Default to qwen-flash (fast, low-cost Qwen3 tier)
 : ${ZSH_AI_QWEN_URL:="https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"}  # Default to Qwen API
 : ${ZSH_AI_ANTHROPIC_MODEL:="claude-haiku-4-5"}  # Default Anthropic model
 : ${ZSH_AI_ANTHROPIC_URL:="https://api.anthropic.com/v1/messages"}  # Default Anthropic URL
-: ${ZSH_AI_GROK_MODEL:="grok-4-1-fast-non-reasoning"}  # Default Grok model
+: ${ZSH_AI_GROK_MODEL:="grok-4.3"}  # Default Grok model (provider sends reasoning_effort=none for speed)
 : ${ZSH_AI_GROK_URL:="https://api.x.ai/v1/chat/completions"}  # Default Grok URL
 : ${ZSH_AI_MISTRAL_MODEL:="mistral-small-latest"}  # Default Mistral model
 : ${ZSH_AI_MISTRAL_URL:="https://api.mistral.ai/v1/chat/completions"}  # Default Mistral URL

--- a/lib/providers/grok.zsh
+++ b/lib/providers/grok.zsh
@@ -31,7 +31,8 @@ _zsh_ai_query_grok() {
         }
     ],
     "max_completion_tokens": 256,
-    "temperature": 0.3
+    "temperature": 0.3,
+    "reasoning_effort": "none"
 }
 EOF
 )

--- a/tests/providers/grok.test.zsh
+++ b/tests/providers/grok.test.zsh
@@ -32,7 +32,7 @@ EOF
 
 test_grok_query_success() {
     export XAI_API_KEY="test-key"
-    export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
+    export ZSH_AI_GROK_MODEL="grok-4.3"
 
     local result=$(_zsh_ai_query_grok "list files")
     assert_equals "$result" "ls -la"
@@ -40,7 +40,7 @@ test_grok_query_success() {
 
 test_grok_query_error_response() {
     export XAI_API_KEY="test-key"
-    export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
+    export ZSH_AI_GROK_MODEL="grok-4.3"
 
     # Override curl to return an error
     curl() {
@@ -63,7 +63,7 @@ EOF
 
 test_grok_json_escaping() {
     export XAI_API_KEY="test-key"
-    export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
+    export ZSH_AI_GROK_MODEL="grok-4.3"
 
     # Test with special characters
     local result=$(_zsh_ai_query_grok "test \"quotes\" and \$variables")
@@ -73,7 +73,7 @@ test_grok_json_escaping() {
 
 test_handles_response_with_newline() {
     export XAI_API_KEY="test-key"
-    export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
+    export ZSH_AI_GROK_MODEL="grok-4.3"
 
     # Override curl to return response with newline
     curl() {
@@ -100,7 +100,7 @@ EOF
 
 test_handles_response_without_jq() {
     export XAI_API_KEY="test-key"
-    export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
+    export ZSH_AI_GROK_MODEL="grok-4.3"
 
     # Mock jq as unavailable
     command() {
@@ -125,7 +125,7 @@ test_handles_response_without_jq() {
 
 test_uses_configurable_api_url() {
     export XAI_API_KEY="test-key"
-    export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
+    export ZSH_AI_GROK_MODEL="grok-4.3"
     export ZSH_AI_GROK_URL="https://custom.grok.api/v1/chat/completions"
 
     # Override curl to check the custom URL is used
@@ -144,9 +144,10 @@ test_uses_configurable_api_url() {
     export ZSH_AI_GROK_URL="https://api.x.ai/v1/chat/completions"
 }
 
-test_uses_max_completion_tokens() {
+# Capture the JSON --data payload sent to the Grok API
+capture_grok_payload() {
     export XAI_API_KEY="test-key"
-    export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
+    export ZSH_AI_GROK_MODEL="grok-4.3"
     local payload_file=$(mktemp)
 
     curl() {
@@ -168,17 +169,25 @@ test_uses_max_completion_tokens() {
     _zsh_ai_query_grok "test" >/dev/null
     local captured_payload=$(cat "$payload_file")
     rm -f "$payload_file"
-    assert_contains "$captured_payload" '"max_completion_tokens"'
+    printf "%s" "$captured_payload"
+}
+
+test_uses_max_completion_tokens() {
+    assert_contains "$(capture_grok_payload)" '"max_completion_tokens"'
 }
 
 test_uses_xai_api_key() {
     export XAI_API_KEY="test-secret-key"
-    export ZSH_AI_GROK_MODEL="grok-4-1-fast-non-reasoning"
+    export ZSH_AI_GROK_MODEL="grok-4.3"
 
     # Test that the function uses XAI_API_KEY (not OPENAI_API_KEY)
     # If XAI_API_KEY is set, the query should succeed
     local result=$(_zsh_ai_query_grok "test")
     assert_not_empty "$result"
+}
+
+test_uses_reasoning_effort_none() {
+    assert_contains "$(capture_grok_payload)" '"reasoning_effort": "none"'
 }
 
 # Run tests
@@ -190,5 +199,6 @@ run_test "Handles response with trailing newline" test_handles_response_with_new
 run_test "Handles response without jq and with newline" test_handles_response_without_jq
 run_test "Uses configurable API URL (ZSH_AI_GROK_URL)" test_uses_configurable_api_url
 run_test "Uses max_completion_tokens parameter" test_uses_max_completion_tokens
+run_test "Uses reasoning_effort=none parameter" test_uses_reasoning_effort_none
 run_test "Uses XAI_API_KEY environment variable" test_uses_xai_api_key
 finish_tests

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -32,7 +32,7 @@ EOF
 
 test_openai_query_success() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
+    export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
 
     local result=$(_zsh_ai_query_openai "list files")
     assert_equals "$result" "ls -la"
@@ -40,7 +40,7 @@ test_openai_query_success() {
 
 test_openai_query_error_response() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
+    export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
     
     # Override curl to return an error
     curl() {
@@ -63,7 +63,7 @@ EOF
 
 test_openai_json_escaping() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
+    export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
     
     # Test with special characters
     local result=$(_zsh_ai_query_openai "test \"quotes\" and \$variables")
@@ -73,7 +73,7 @@ test_openai_json_escaping() {
 
 test_handles_response_with_newline() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
+    export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
     export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
 
     # Override curl to return response with newline
@@ -101,7 +101,7 @@ EOF
 
 test_handles_response_without_jq() {
     export OPENAI_API_KEY="test-key"
-    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
+    export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
 
     # Mock jq as unavailable
     command() {
@@ -198,7 +198,7 @@ test_uses_max_completion_tokens_for_o1_models() {
 }
 
 test_omits_temperature_for_gpt5_models() {
-    local captured_payload=$(capture_openai_payload_for_model "gpt-5-mini")
+    local captured_payload=$(capture_openai_payload_for_model "gpt-5.4-mini")
     assert_not_contains "$captured_payload" '"temperature"'
 }
 
@@ -334,7 +334,7 @@ test_openai_zsh_ai_key_takes_precedence() {
     export OPENAI_API_KEY="original-key"
     export ZSH_AI_OPENAI_API_KEY="override-key"
     export ZSH_AI_PROVIDER="openai"
-    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
+    export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
     export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
     local curl_args_file=$(mktemp)
 
@@ -367,7 +367,7 @@ test_openai_falls_back_to_openai_api_key() {
     unset ZSH_AI_OPENAI_API_KEY
     export OPENAI_API_KEY="fallback-key"
     export ZSH_AI_PROVIDER="openai"
-    export ZSH_AI_OPENAI_MODEL="gpt-5-mini"
+    export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
     export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
     local curl_args_file=$(mktemp)
 

--- a/tests/providers/qwen.test.zsh
+++ b/tests/providers/qwen.test.zsh
@@ -32,7 +32,7 @@ EOF
 
 test_qwen_query_success() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen-plus"
+    export ZSH_AI_QWEN_MODEL="qwen-flash"
 
     local result=$(_zsh_ai_query_qwen "list files")
     assert_equals "$result" "ls -la"
@@ -40,7 +40,7 @@ test_qwen_query_success() {
 
 test_qwen_query_error_response() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen-plus"
+    export ZSH_AI_QWEN_MODEL="qwen-flash"
 
     # Override curl to return an error
     curl() {
@@ -63,7 +63,7 @@ EOF
 
 test_qwen_json_escaping() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen-plus"
+    export ZSH_AI_QWEN_MODEL="qwen-flash"
 
     # Test with special characters
     local result=$(_zsh_ai_query_qwen "test \"quotes\" and \$variables")
@@ -73,7 +73,7 @@ test_qwen_json_escaping() {
 
 test_handles_response_with_newline() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen-plus"
+    export ZSH_AI_QWEN_MODEL="qwen-flash"
 
     # Override curl to return response with newline
     curl() {
@@ -100,7 +100,7 @@ EOF
 
 test_handles_response_without_jq() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen-plus"
+    export ZSH_AI_QWEN_MODEL="qwen-flash"
 
     # Mock jq as unavailable
     command() {
@@ -125,7 +125,7 @@ test_handles_response_without_jq() {
 
 test_uses_configurable_api_url() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen-plus"
+    export ZSH_AI_QWEN_MODEL="qwen-flash"
     export ZSH_AI_QWEN_URL="https://custom.qwen.api/v1/chat/completions"
 
     # Override curl to check the custom URL is used
@@ -146,7 +146,7 @@ test_uses_configurable_api_url() {
 
 test_uses_max_tokens() {
     export QWEN_API_KEY="test-key"
-    export ZSH_AI_QWEN_MODEL="qwen-plus"
+    export ZSH_AI_QWEN_MODEL="qwen-flash"
     local payload_file=$(mktemp)
 
     curl() {
@@ -173,7 +173,7 @@ test_uses_max_tokens() {
 
 test_uses_qwen_api_key() {
     export QWEN_API_KEY="test-secret-key"
-    export ZSH_AI_QWEN_MODEL="qwen-plus"
+    export ZSH_AI_QWEN_MODEL="qwen-flash"
     local curl_args_file=$(mktemp)
 
     curl() {


### PR DESCRIPTION
The OpenAI and Grok defaults had gone stale. `gpt-5-mini` is deprecated (shuts down Dec 2026) and `grok-4-1-fast-non-reasoning` was retired in May 2026, where it now silently redirects to grok-4.3 at roughly 6x the cost. This refreshes both to current models and moves Qwen to its faster, lower-cost tier.

- **OpenAI** `gpt-5-mini` → `gpt-5.4-mini` (official replacement; the existing `gpt-5*` parameter routing already covers it)
- **Grok** `grok-4-1-fast-non-reasoning` → `grok-4.3`, with `reasoning_effort: none` added so it stays fast and spends no reasoning tokens
- **Qwen** `qwen-plus` → `qwen-flash` (low-cost Qwen3 tier, drop-in)

Anthropic, Gemini, Ollama, and Mistral defaults are still current, so they're left unchanged. All 188 tests pass.
