### PR TITLE
Add OpenAI-compatible reasoning effort option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,6 +135,8 @@ export ZSH_AI_OPENAI_API_KEY="sk-your-proxy-key"
 
 `ZSH_AI_OPENAI_THINKING` sets the `chat_template_kwargs.enable_thinking` parameter, which is a non-standard API that controls thinking output for reasoning models with chat templates. Set to `0` to disable, `1` to enable, or leave unset for upstream defaults.
 
+`ZSH_AI_OPENAI_REASONING_EFFORT` sets the `reasoning_effort` parameter for OpenAI-compatible endpoints that support it. For example, Groq supports `none` and `default` for `qwen/qwen3.6-27b`; set `none` to disable reasoning tokens. Common values are `none`, `default`, `minimal`, `low`, `medium`, and `high`; leave unset for upstream defaults.
+
 ## Load zsh-ai
 
 Put the load line after your provider block in `~/.zshrc`.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ export ZSH_AI_PROVIDER="openai"
 export OPENAI_API_KEY="your-key-here"
 ```
 
+OpenAI-compatible endpoints can also pass provider-specific reasoning controls:
+
+```bash
+export ZSH_AI_OPENAI_REASONING_EFFORT="none"
+```
+
 Add command preferences without replacing the built-in quoting rules:
 
 ```bash

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -10,6 +10,7 @@
 : ${ZSH_AI_OPENAI_MODEL:="gpt-5.4-mini"}  # Default to GPT-5.4 mini (gpt-5-mini is deprecated)
 : ${ZSH_AI_OPENAI_URL:="https://api.openai.com/v1/chat/completions"}  # Default to OpenAI
 : ${ZSH_AI_OPENAI_THINKING:=""}  # Configure thinking for supported models: 0 or 1, default unset/empty
+: ${ZSH_AI_OPENAI_REASONING_EFFORT:=""}  # Configure reasoning effort for supported OpenAI-compatible models
 : ${ZSH_AI_QWEN_MODEL:="qwen-flash"}  # Default to qwen-flash (fast, low-cost Qwen3 tier)
 : ${ZSH_AI_QWEN_URL:="https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"}  # Default to Qwen API
 : ${ZSH_AI_ANTHROPIC_MODEL:="claude-haiku-4-5"}  # Default Anthropic model
@@ -68,6 +69,7 @@ _zsh_ai_validate_config() {
             echo "zsh-ai: Error: ZSH_AI_OPENAI_THINKING must be 0, 1, or unset."
             return 1
         fi
+
     elif [[ "$ZSH_AI_PROVIDER" == "qwen" ]]; then
         if [[ -z "$QWEN_API_KEY" ]]; then
             echo "zsh-ai: Warning: QWEN_API_KEY not set. Plugin will not function."

--- a/lib/providers/openai.zsh
+++ b/lib/providers/openai.zsh
@@ -41,6 +41,11 @@ _zsh_ai_query_openai() {
         1) thinking_param=$',\n    "chat_template_kwargs": { "enable_thinking": true }' ;;
     esac
 
+    local reasoning_effort_param=""
+    if [[ -n "$ZSH_AI_OPENAI_REASONING_EFFORT" ]]; then
+        reasoning_effort_param=$',\n    "reasoning_effort": "'"$(_zsh_ai_escape_json "$ZSH_AI_OPENAI_REASONING_EFFORT")"'"'
+    fi
+
     local json_payload=$(cat <<EOF
 {
     "model": "${ZSH_AI_OPENAI_MODEL}",
@@ -54,7 +59,7 @@ _zsh_ai_query_openai() {
             "content": "$escaped_query"
         }
     ],
-    "$token_param": 256${temperature_param}${thinking_param}
+    "$token_param": 256${temperature_param}${thinking_param}${reasoning_effort_param}
 }
 EOF
 )

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -33,6 +33,7 @@ EOF
 test_openai_query_success() {
     export OPENAI_API_KEY="test-key"
     export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
+    export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
 
     local result=$(_zsh_ai_query_openai "list files")
     assert_equals "$result" "ls -la"
@@ -41,6 +42,7 @@ test_openai_query_success() {
 test_openai_query_error_response() {
     export OPENAI_API_KEY="test-key"
     export ZSH_AI_OPENAI_MODEL="gpt-5.4-mini"
+    export ZSH_AI_OPENAI_URL="https://api.openai.com/v1/chat/completions"
     
     # Override curl to return an error
     curl() {
@@ -437,4 +439,38 @@ run_test "ZSH_AI_OPENAI_THINKING unset omits chat_template_kwargs parameter" tes
 run_test "ZSH_AI_OPENAI_THINKING=1 sets enable_thinking true" test_openai_thinking_enabled_sets_true
 run_test "ZSH_AI_OPENAI_THINKING=0 sets enable_thinking false" test_openai_thinking_disabled_sets_false
 run_test "Invalid ZSH_AI_OPENAI_THINKING value returns error" test_openai_thinking_invalid_value_returns_error
+
+# Tests for ZSH_AI_OPENAI_REASONING_EFFORT
+echo ""
+echo "Running OpenAI-compatible reasoning effort tests..."
+
+test_openai_reasoning_effort_unset_omits_param() {
+    export ZSH_AI_PROVIDER="openai"
+    unset ZSH_AI_OPENAI_THINKING
+    unset ZSH_AI_OPENAI_REASONING_EFFORT
+    local captured_payload=$(capture_openai_payload_for_model "qwen/qwen3.6-27b")
+    assert_not_contains "$captured_payload" '"reasoning_effort"'
+}
+
+test_openai_reasoning_effort_sets_value() {
+    export ZSH_AI_PROVIDER="openai"
+    unset ZSH_AI_OPENAI_THINKING
+    export ZSH_AI_OPENAI_REASONING_EFFORT="none"
+    local captured_payload=$(capture_openai_payload_for_model "qwen/qwen3.6-27b")
+    unset ZSH_AI_OPENAI_REASONING_EFFORT
+    assert_contains "$captured_payload" '"reasoning_effort": "none"'
+}
+
+test_openai_reasoning_effort_escapes_value() {
+    export ZSH_AI_PROVIDER="openai"
+    unset ZSH_AI_OPENAI_THINKING
+    export ZSH_AI_OPENAI_REASONING_EFFORT='custom"tier'
+    local captured_payload=$(capture_openai_payload_for_model "qwen/qwen3.6-27b")
+    unset ZSH_AI_OPENAI_REASONING_EFFORT
+    assert_contains "$captured_payload" '"reasoning_effort": "custom\"tier"'
+}
+
+run_test "ZSH_AI_OPENAI_REASONING_EFFORT unset omits reasoning_effort parameter" test_openai_reasoning_effort_unset_omits_param
+run_test "ZSH_AI_OPENAI_REASONING_EFFORT sets reasoning_effort value" test_openai_reasoning_effort_sets_value
+run_test "ZSH_AI_OPENAI_REASONING_EFFORT escapes reasoning_effort value" test_openai_reasoning_effort_escapes_value
 finish_tests

--- a/tests/test_helper.zsh
+++ b/tests/test_helper.zsh
@@ -182,6 +182,8 @@ setup_test_env() {
     export ZSH_AI_PROVIDER=""
     export ANTHROPIC_API_KEY=""
     export ZSH_AI_MODEL=""
+    unset ZSH_AI_TRIGGER
+    unset ZSH_AI_COMMENT_HOOK
     
     # Reset mocks
     reset_mocks
@@ -197,6 +199,8 @@ teardown_test_env() {
     unset ZSH_AI_PROVIDER
     unset ANTHROPIC_API_KEY
     unset ZSH_AI_MODEL
+    unset ZSH_AI_TRIGGER
+    unset ZSH_AI_COMMENT_HOOK
     unset ZSH_AI_TEST_MODE
 }
 


### PR DESCRIPTION
## Summary

Adds `ZSH_AI_OPENAI_REASONING_EFFORT` for OpenAI-compatible endpoints that support the `reasoning_effort` request parameter.

This is useful for providers such as Groq, where models like `qwen/qwen3.6-27b` support `reasoning_effort=none` to disable reasoning tokens. This complements the existing `ZSH_AI_OPENAI_THINKING` option, which controls the non-standard `chat_template_kwargs.enable_thinking` field.

## Changes

- Add `ZSH_AI_OPENAI_REASONING_EFFORT` config default
- Pass `reasoning_effort` through to OpenAI-compatible request payloads when set
- JSON-escape the configured reasoning effort value before building the payload
- Document the option in `README.md` and `INSTALL.md`
- Add OpenAI provider tests for omitted, included, and escaped values
- Reset trigger/comment-hook test env so widget tests are not affected by user shell config

## Testing

- `./run-tests.zsh tests/providers`
- `./run-tests.zsh`
- `git diff --check`
