### PR TITLE
Add support for custom provider hook

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -151,7 +151,7 @@ export ZSH_AI_PROVIDER="custom"
 
 _zsh_ai_query_custom() {
 	local query="${1-}"
-	local system_prompt_file response
+	local system_prompt_file response ret
 
 	local system_prompt_file=$(mktemp)
 	_zsh_ai_get_system_prompt > "$system_prompt_file"
@@ -173,9 +173,10 @@ _zsh_ai_query_custom() {
 		}
 	)
 
-	if (( status != 0 )); then
+	ret=$?
+	if (( ret != 0 )); then
 		echo "Error: Something went wrong while running codex."
-		return "$status"
+		return $ret
 	fi
 
 	printf '%s\n' "$response"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,6 +160,7 @@ _zsh_ai_query_custom() {
 				--sandbox read-only \
 				--model 'gpt-5.6-luna' \
 				--config model_reasoning_effort=low \
+				--config project_doc_max_bytes=0 \
 				--config "model_instructions_file=\"$system_prompt_file\"" \
 				-- "$query" \
 				2>/dev/null

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -139,12 +139,7 @@ export ZSH_AI_OPENAI_API_KEY="sk-your-proxy-key"
 
 ## Custom Provider
 
-Set `ZSH_AI_PROVIDER` to `custom` and define `_zsh_ai_query_custom` before
-`zsh-ai` loads. The function receives the natural-language query as its first
-argument. It must print only the generated command to standard output, and
-return a non-zero status when the provider fails, optionally printing an error message to standard output.
-
-This example uses the Codex CLI:
+Set `ZSH_AI_PROVIDER` to `custom` and define `_zsh_ai_query_custom` before `zsh-ai` loads. The function receives the natural-language query as its first argument. It must print only the generated command to standard output. If the provider fails, the function must print a message prefixed with `Error:` to the standard output, and/or return a non-zero status. This example uses the Codex CLI:
 
 ```zsh
 export ZSH_AI_PROVIDER="custom"
@@ -183,8 +178,7 @@ _zsh_ai_query_custom() {
 }
 ```
 
-Replace the model and CLI options with those supported by your Codex setup, or
-replace the function body entirely to call any local command or remote API.
+Replace the model and CLI options with those supported by your Codex setup, or replace the function body entirely to call any local command or remote API.
 
 ## Load zsh-ai
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,6 +137,54 @@ export ZSH_AI_OPENAI_API_KEY="sk-your-proxy-key"
 
 `ZSH_AI_OPENAI_REASONING_EFFORT` sets the `reasoning_effort` parameter for OpenAI-compatible endpoints that support it. For example, Groq supports `none` and `default` for `qwen/qwen3.6-27b`; set `none` to disable reasoning tokens. Common values are `none`, `default`, `minimal`, `low`, `medium`, and `high`; leave unset for upstream defaults.
 
+## Custom Provider
+
+Set `ZSH_AI_PROVIDER` to `custom` and define `_zsh_ai_query_custom` before
+`zsh-ai` loads. The function receives the natural-language query as its first
+argument. It must print only the generated command to standard output, and
+return a non-zero status when the provider fails, optionally printing an error message to standard output.
+
+This example uses the Codex CLI:
+
+```zsh
+export ZSH_AI_PROVIDER="custom"
+
+_zsh_ai_query_custom() {
+	local query="${1-}"
+	local system_prompt_file response
+
+	local system_prompt_file=$(mktemp)
+	_zsh_ai_get_system_prompt > "$system_prompt_file"
+
+	response=$(
+		{
+			codex exec \
+				--ephemeral \
+				--ignore-user-config \
+				--skip-git-repo-check \
+				--sandbox read-only \
+				--model 'gpt-5.6-luna' \
+				--config model_reasoning_effort=low \
+				--config "model_instructions_file=\"$system_prompt_file\"" \
+				-- "$query" \
+				2>/dev/null
+		} always {
+			rm -f -- "$system_prompt_file"
+		}
+	)
+
+	if (( status != 0 )); then
+		echo "Error: Something went wrong while running codex."
+		return "$status"
+	fi
+
+	printf '%s\n' "$response"
+}
+```
+
+Replace the model and CLI options with those supported by your Codex setup, or
+replace the function body entirely to call any local command or remote API.
+
 ## Load zsh-ai
 
 Put the load line after your provider block in `~/.zshrc`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -149,7 +149,7 @@ _zsh_ai_query_custom() {
 	local system_prompt_file response ret
 
 	local system_prompt_file=$(mktemp)
-	_zsh_ai_get_system_prompt > "$system_prompt_file"
+	_zsh_ai_get_system_prompt "$(_zsh_ai_build_context)" > "$system_prompt_file"
 
 	response=$(
 		{

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -38,7 +38,7 @@ _zsh_ai_comment_hook_enabled() {
 
 # Provider validation
 _zsh_ai_validate_config() {
-    if [[ "$ZSH_AI_PROVIDER" != "anthropic" ]] && [[ "$ZSH_AI_PROVIDER" != "ollama" ]] && [[ "$ZSH_AI_PROVIDER" != "gemini" ]] && [[ "$ZSH_AI_PROVIDER" != "qwen" ]] && [[ "$ZSH_AI_PROVIDER" != "openai" ]] && [[ "$ZSH_AI_PROVIDER" != "grok" ]] && [[ "$ZSH_AI_PROVIDER" != "mistral" ]]; then
+    if [[ "$ZSH_AI_PROVIDER" != "anthropic" ]] && [[ "$ZSH_AI_PROVIDER" != "ollama" ]] && [[ "$ZSH_AI_PROVIDER" != "gemini" ]] && [[ "$ZSH_AI_PROVIDER" != "qwen" ]] && [[ "$ZSH_AI_PROVIDER" != "openai" ]] && [[ "$ZSH_AI_PROVIDER" != "grok" ]] && [[ "$ZSH_AI_PROVIDER" != "mistral" ]] && [[ "$ZSH_AI_PROVIDER" != "custom" ]]; then
         echo "zsh-ai: Error: Invalid provider '$ZSH_AI_PROVIDER'. Use 'anthropic', 'ollama', 'gemini', 'openai', 'qwen', 'grok', or 'mistral'."
         return 1
     fi
@@ -86,6 +86,12 @@ _zsh_ai_validate_config() {
         if [[ -z "$MISTRAL_API_KEY" ]]; then
             echo "zsh-ai: Warning: MISTRAL_API_KEY not set. Plugin will not function."
             echo "zsh-ai: Set MISTRAL_API_KEY or use ZSH_AI_PROVIDER=ollama for local models."
+            return 1
+        fi
+    elif [[ "$ZSH_AI_PROVIDER" == "custom" ]]; then
+        if (( ! $+functions[_zsh_ai_query_custom] )); then
+            echo "zsh-ai: Warning: _zsh_ai_query_custom is not defined. Plugin will not function."
+            echo "zsh-ai: Define _zsh_ai_query_custom to use a custom provider."
             return 1
         fi
     fi

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -39,7 +39,7 @@ _zsh_ai_comment_hook_enabled() {
 # Provider validation
 _zsh_ai_validate_config() {
     if [[ "$ZSH_AI_PROVIDER" != "anthropic" ]] && [[ "$ZSH_AI_PROVIDER" != "ollama" ]] && [[ "$ZSH_AI_PROVIDER" != "gemini" ]] && [[ "$ZSH_AI_PROVIDER" != "qwen" ]] && [[ "$ZSH_AI_PROVIDER" != "openai" ]] && [[ "$ZSH_AI_PROVIDER" != "grok" ]] && [[ "$ZSH_AI_PROVIDER" != "mistral" ]] && [[ "$ZSH_AI_PROVIDER" != "custom" ]]; then
-        echo "zsh-ai: Error: Invalid provider '$ZSH_AI_PROVIDER'. Use 'anthropic', 'ollama', 'gemini', 'openai', 'qwen', 'grok', or 'mistral'."
+        echo "zsh-ai: Error: Invalid provider '$ZSH_AI_PROVIDER'. Use 'anthropic', 'ollama', 'gemini', 'openai', 'qwen', 'grok', 'mistral', or 'custom'."
         return 1
     fi
 

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -43,7 +43,9 @@ _zsh_ai_query() {
         _zsh_ai_query_grok "$query"
     elif [[ "$ZSH_AI_PROVIDER" == "mistral" ]]; then
         _zsh_ai_query_mistral "$query"
-    else
+    elif [[ "$ZSH_AI_PROVIDER" == "custom" ]]; then
+        _zsh_ai_query_custom "$query"
+	else
         _zsh_ai_query_anthropic "$query"
     fi
 }

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -50,21 +50,6 @@ _zsh_ai_query() {
     fi
 }
 
-# Shared function to handle AI command execution
-_zsh_ai_execute_command() {
-    local query="$1"
-    local cmd=$(_zsh_ai_query "$query")
-    
-    if [[ -n "$cmd" ]] && [[ "$cmd" != "Error:"* ]] && [[ "$cmd" != "API Error:"* ]]; then
-        echo "$cmd"
-        return 0
-    else
-        # Return error
-        echo "$cmd"
-        return 1
-    fi
-}
-
 # Optional: Add a helper function for users who prefer explicit commands
 zsh-ai() {
     if [[ $# -eq 0 ]]; then
@@ -101,7 +86,7 @@ zsh-ai() {
     setopt local_options no_monitor no_notify no_bg_nice
 
     # Start the API query in background
-    (_zsh_ai_execute_command "$query" > "$tmpfile" 2>/dev/null) &
+    (_zsh_ai_query "$query" > "$tmpfile" 2>/dev/null) &
     local pid=$!
     
     # Animate while waiting

--- a/lib/widget.zsh
+++ b/lib/widget.zsh
@@ -34,7 +34,7 @@ _zsh_ai_accept_line() {
         
         # Start the API query in background using the shared function
         # Only redirect stdout to tmpfile, let stderr go to /dev/null to avoid mixing error output
-        (_zsh_ai_execute_command "$query" > "$tmpfile" 2>/dev/null) &
+        (_zsh_ai_query "$query" > "$tmpfile" 2>/dev/null) &
         local pid=$!
         
         # Animate while waiting

--- a/tests/config.test.zsh
+++ b/tests/config.test.zsh
@@ -79,6 +79,53 @@ test_validates_openai_provider() {
     teardown_test_env
 }
 
+test_validates_custom_provider() {
+      local had_custom_function=$+functions[_zsh_ai_query_custom]
+      local saved_custom_function="${functions[_zsh_ai_query_custom]-}"
+
+      {
+          setup_test_env
+          export ZSH_AI_PROVIDER="custom"
+
+          _zsh_ai_query_custom() {
+              return 0
+          }
+
+          _zsh_ai_validate_config >/dev/null 2>&1
+          assert_equals "$?" "0"
+      } always {
+          teardown_test_env
+
+          if (( had_custom_function )); then
+              functions[_zsh_ai_query_custom]="$saved_custom_function"
+          else
+              unfunction _zsh_ai_query_custom 2>/dev/null
+          fi
+      }
+}
+
+test_rejects_missing_custom_provider_function() {
+      local had_custom_function=$+functions[_zsh_ai_query_custom]
+      local saved_custom_function="${functions[_zsh_ai_query_custom]-}"
+
+      {
+          setup_test_env
+          export ZSH_AI_PROVIDER="custom"
+          unfunction _zsh_ai_query_custom 2>/dev/null
+
+          _zsh_ai_validate_config >/dev/null 2>&1
+          assert_equals "$?" "1"
+      } always {
+          teardown_test_env
+
+          if (( had_custom_function )); then
+              functions[_zsh_ai_query_custom]="$saved_custom_function"
+          else
+              unfunction _zsh_ai_query_custom 2>/dev/null
+          fi
+      }
+}
+
 test_comment_hook_enabled_by_default() {
     setup_test_env
     unset ZSH_AI_COMMENT_HOOK
@@ -119,6 +166,8 @@ run_test "Validates ollama provider" test_validates_ollama_provider
 run_test "Rejects invalid provider" test_rejects_invalid_provider
 run_test "Validates gemini provider" test_validates_gemini_provider
 run_test "Validates openai provider" test_validates_openai_provider
+run_test "Validates custom provider" test_validates_custom_provider
+run_test "Rejects missing custom provider function" test_rejects_missing_custom_provider_function
 run_test "Comment hook enabled by default" test_comment_hook_enabled_by_default
 run_test "Comment hook can be disabled" test_comment_hook_can_be_disabled
 run_test "Default trigger is '# '" test_default_trigger_is_hash

--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -30,6 +30,44 @@ test_routes_to_anthropic_provider() {
     teardown_test_env
 }
 
+test_routes_to_custom_provider() {
+    setup_test_env
+    export ZSH_AI_PROVIDER="custom"
+
+    # Mock custom provider
+    _zsh_ai_query_custom() {
+        echo "custom:$1"
+    }
+    
+    local output
+    output=$(_zsh_ai_query "test query")
+    assert_equals "$output" "custom:test query"
+
+    teardown_test_env
+}
+
+test_provider_non_zero_exit_code() {
+    setup_test_env
+    export ZSH_AI_PROVIDER="anthropic"
+    export ANTHROPIC_API_KEY="test-key"
+
+    _zsh_ai_query_anthropic() {
+        echo "Not prefixed with 'Error:'"
+        return 1
+    }
+
+    # Capture output with stderr
+    local output
+    output=$(zsh-ai "test query" 2>&1)
+    local result=$?
+
+    assert_equals "$result" "1"
+    assert_contains "$output" "Failed to generate command"
+    assert_contains "$output" "Not prefixed with 'Error:'"
+
+    teardown_test_env
+}
+
 test_routes_to_ollama_provider() {
     setup_test_env
     export ZSH_AI_PROVIDER="ollama"
@@ -219,7 +257,7 @@ test_combines_multiple_arguments() {
     export ANTHROPIC_API_KEY="test-key"
     
     # Mock execute command function
-    _zsh_ai_execute_command() {
+    _zsh_ai_query() {
         echo "find . -name '*.py'"
     }
     
@@ -247,7 +285,7 @@ test_puts_generated_command_in_buffer() {
     export ANTHROPIC_API_KEY="test-key"
     
     # Mock execute command function
-    _zsh_ai_execute_command() {
+    _zsh_ai_query() {
         echo "ls -la"
     }
     
@@ -275,7 +313,7 @@ test_no_execution_happens() {
     export ANTHROPIC_API_KEY="test-key"
     
     # Mock execute command function
-    _zsh_ai_execute_command() {
+    _zsh_ai_query() {
         echo "pwd"
     }
     
@@ -311,7 +349,7 @@ test_shows_loading_spinner() {
     export ANTHROPIC_API_KEY="test-key"
     
     # Mock execute command function with delay to simulate API call
-    _zsh_ai_execute_command() {
+    _zsh_ai_query() {
         sleep 0.3
         echo "ls -la"
     }
@@ -471,6 +509,8 @@ test_get_system_prompt_with_empty_extension() {
 echo "Running utils tests..."
 run_test "Routes to Anthropic provider when configured" test_routes_to_anthropic_provider
 run_test "Routes to Ollama provider when configured" test_routes_to_ollama_provider
+run_test "Routes to custom provider when configured" test_routes_to_custom_provider
+run_test "Throws an error when provider returns non-zero exit code" test_provider_non_zero_exit_code
 run_test "Checks Ollama availability before querying" test_checks_ollama_availability_before_querying
 run_test "Shows usage when called without arguments" test_shows_usage_without_arguments
 run_test "Shows Ollama model in usage for Ollama provider" test_shows_ollama_model_in_usage

--- a/tests/widget.test.zsh
+++ b/tests/widget.test.zsh
@@ -458,7 +458,7 @@ test_custom_trigger_is_processed() {
     # Echo back the query so we can verify the trigger prefix was stripped.
     # The widget runs this in a background subshell and reads its stdout from a
     # temp file, so we rely on a real temp file rather than mocking cat/mktemp.
-    _zsh_ai_execute_command() {
+    _zsh_ai_query() {
         printf "query:%s" "$1"
     }
 


### PR DESCRIPTION
This PR adds support for a custom provider via `ZSH_AI_PROVIDER="custom"`, which requires a user-supplied function `_zsh_ai_query_custom`.
- config validation checks for the existence of `_zsh_ai_query_custom`
- `INSTALL.md` contains an example of using the codex CLI via `codex exec`. 