### PR TITLE
Fix noclobber breakage and clarify Ollama URL misconfig errors

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -26,15 +26,24 @@ Or switch to Ollama:
 export ZSH_AI_PROVIDER="ollama"
 ```
 
-## Ollama Is Not Running
+## Ollama Is Not Reachable
 
 ```bash
-Error: Ollama is not running at http://localhost:11434
+Error: Ollama is not reachable at http://localhost:11434
 ```
+
+If Ollama isn't running yet:
 
 ```bash
 ollama serve
 ollama pull llama3.2
+```
+
+If it's already running, check `ZSH_AI_OLLAMA_URL`. It must be the base URL with
+no path suffix (`/v1` is for OpenAI-compatible clients, not this plugin):
+
+```bash
+export ZSH_AI_OLLAMA_URL="http://localhost:11434"
 ```
 
 ## Nothing Happens With `#`

--- a/lib/providers/ollama.zsh
+++ b/lib/providers/ollama.zsh
@@ -3,8 +3,10 @@
 # Ollama API provider for zsh-ai
 
 # Function to check if Ollama is running
+# -f makes HTTP errors fail the check, so a wrong URL (e.g. a /v1 suffix
+# that 404s) is caught here instead of surfacing later as a parse error
 _zsh_ai_check_ollama() {
-    curl -s "${ZSH_AI_OLLAMA_URL}/api/tags" >/dev/null 2>&1
+    curl -sf "${ZSH_AI_OLLAMA_URL}/api/tags" >/dev/null 2>&1
     return $?
 }
 
@@ -55,6 +57,7 @@ EOF
                 echo "Ollama Error: $error"
             else
                 echo "Error: Unable to parse Ollama response"
+                [[ -n "$response" ]] && echo "Response: ${response:0:200}"
             fi
             return 1
         fi
@@ -75,6 +78,7 @@ EOF
 
         if [[ -z "$result" ]]; then
             echo "Error: Unable to parse response (install jq for better reliability)"
+            [[ -n "$response" ]] && echo "Response: ${response:0:200}"
             return 1
         fi
 

--- a/lib/providers/ollama.zsh
+++ b/lib/providers/ollama.zsh
@@ -2,12 +2,17 @@
 
 # Ollama API provider for zsh-ai
 
-# Function to check if Ollama is running
+# Function to check if Ollama is reachable, printing the user-facing error when it isn't
 # -f makes HTTP errors fail the check, so a wrong URL (e.g. a /v1 suffix
 # that 404s) is caught here instead of surfacing later as a parse error
 _zsh_ai_check_ollama() {
-    curl -sf "${ZSH_AI_OLLAMA_URL}/api/tags" >/dev/null 2>&1
-    return $?
+    if curl -sf "${ZSH_AI_OLLAMA_URL}/api/tags" >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "Error: Ollama is not reachable at $ZSH_AI_OLLAMA_URL"
+    echo "Start Ollama with: ollama serve"
+    echo "If it's already running, ZSH_AI_OLLAMA_URL must be the base URL (e.g. http://localhost:11434, no /v1)"
+    return 1
 }
 
 # Function to call Ollama API

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -86,7 +86,8 @@ zsh-ai() {
     setopt local_options no_monitor no_notify no_bg_nice
 
     # Start the API query in background
-    (_zsh_ai_query "$query" > "$tmpfile" 2>/dev/null) &
+    # >| so the redirect works when the user has noclobber set (mktemp already created the file)
+    (_zsh_ai_query "$query" >| "$tmpfile" 2>/dev/null) &
     local pid=$!
     
     # Animate while waiting

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -26,13 +26,8 @@ _zsh_ai_query() {
     local query="$1"
 
     if [[ "$ZSH_AI_PROVIDER" == "ollama" ]]; then
-        # Check if Ollama is running first
-        if ! _zsh_ai_check_ollama; then
-            echo "Error: Ollama is not reachable at $ZSH_AI_OLLAMA_URL"
-            echo "Start Ollama with: ollama serve"
-            echo "If it's already running, ZSH_AI_OLLAMA_URL must be the base URL (e.g. http://localhost:11434, no /v1)"
-            return 1
-        fi
+        # The check prints its own user-facing error when Ollama is unreachable
+        _zsh_ai_check_ollama || return 1
         _zsh_ai_query_ollama "$query"
     elif [[ "$ZSH_AI_PROVIDER" == "gemini" ]]; then
         _zsh_ai_query_gemini "$query"

--- a/lib/utils.zsh
+++ b/lib/utils.zsh
@@ -28,8 +28,9 @@ _zsh_ai_query() {
     if [[ "$ZSH_AI_PROVIDER" == "ollama" ]]; then
         # Check if Ollama is running first
         if ! _zsh_ai_check_ollama; then
-            echo "Error: Ollama is not running at $ZSH_AI_OLLAMA_URL"
+            echo "Error: Ollama is not reachable at $ZSH_AI_OLLAMA_URL"
             echo "Start Ollama with: ollama serve"
+            echo "If it's already running, ZSH_AI_OLLAMA_URL must be the base URL (e.g. http://localhost:11434, no /v1)"
             return 1
         fi
         _zsh_ai_query_ollama "$query"

--- a/lib/widget.zsh
+++ b/lib/widget.zsh
@@ -34,7 +34,8 @@ _zsh_ai_accept_line() {
         
         # Start the API query in background using the shared function
         # Only redirect stdout to tmpfile, let stderr go to /dev/null to avoid mixing error output
-        (_zsh_ai_query "$query" > "$tmpfile" 2>/dev/null) &
+        # >| so the redirect works when the user has noclobber set (mktemp already created the file)
+        (_zsh_ai_query "$query" >| "$tmpfile" 2>/dev/null) &
         local pid=$!
         
         # Animate while waiting

--- a/tests/providers/ollama.test.zsh
+++ b/tests/providers/ollama.test.zsh
@@ -34,12 +34,15 @@ test_check_ollama_running_failure() {
     
     # Mock curl failure
     mock_command "curl" "" 1
-    
-    _zsh_ai_check_ollama
+
+    local output
+    output=$(_zsh_ai_check_ollama)
     local result=$?
-    
+
     assert_equals "$result" "1"
-    
+    assert_contains "$output" "Ollama is not reachable"
+    assert_contains "$output" "no /v1"
+
     teardown_test_env
 }
 
@@ -61,10 +64,12 @@ test_check_ollama_fails_on_http_error() {
         return 0
     }
 
-    _zsh_ai_check_ollama
+    local output
+    output=$(_zsh_ai_check_ollama)
     local result=$?
 
     assert_greater_than "$result" "0"
+    assert_contains "$output" "Ollama is not reachable"
 
     teardown_test_env
 }

--- a/tests/providers/ollama.test.zsh
+++ b/tests/providers/ollama.test.zsh
@@ -43,6 +43,76 @@ test_check_ollama_running_failure() {
     teardown_test_env
 }
 
+test_check_ollama_fails_on_http_error() {
+    setup_test_env
+    export ZSH_AI_OLLAMA_MODEL="llama3.2"
+    export ZSH_AI_OLLAMA_URL="http://localhost:11434/v1"
+
+    # Simulate a running server that 404s the wrong path (e.g. a /v1 suffix
+    # in the URL): curl only fails on HTTP errors when -f is passed
+    curl() {
+        local arg
+        for arg in "$@"; do
+            if [[ "$arg" == -* && "$arg" == *f* ]]; then
+                return 22
+            fi
+        done
+        printf "404 page not found"
+        return 0
+    }
+
+    _zsh_ai_check_ollama
+    local result=$?
+
+    assert_greater_than "$result" "0"
+
+    teardown_test_env
+}
+
+test_parse_error_shows_raw_response_with_jq() {
+    setup_test_env
+    export ZSH_AI_OLLAMA_MODEL="llama3.2"
+    export ZSH_AI_OLLAMA_URL="http://localhost:11434"
+
+    # Mock jq as available
+    mock_jq "true"
+
+    # Mock a non-JSON body (what a misconfigured URL actually returns)
+    mock_curl_response '404 page not found' 0
+
+    local output
+    output=$(_zsh_ai_query_ollama "test query")
+    local result=$?
+
+    assert_equals "$result" "1"
+    assert_contains "$output" "Unable to parse Ollama response"
+    assert_contains "$output" "404 page not found"
+
+    teardown_test_env
+}
+
+test_parse_error_shows_raw_response_without_jq() {
+    setup_test_env
+    export ZSH_AI_OLLAMA_MODEL="llama3.2"
+    export ZSH_AI_OLLAMA_URL="http://localhost:11434"
+
+    # Mock jq as unavailable
+    mock_jq "false"
+
+    # Mock a non-JSON body (what a misconfigured URL actually returns)
+    mock_curl_response '404 page not found' 0
+
+    local output
+    output=$(_zsh_ai_query_ollama "test query")
+    local result=$?
+
+    assert_equals "$result" "1"
+    assert_contains "$output" "install jq"
+    assert_contains "$output" "404 page not found"
+
+    teardown_test_env
+}
+
 test_successful_api_call_with_jq() {
     setup_test_env
     export ZSH_AI_OLLAMA_MODEL="llama3.2"
@@ -405,6 +475,9 @@ test_handles_thinking_model_response() {
 echo "Running ollama provider tests..."
 run_test "Check if Ollama is running - success" test_check_ollama_running_success
 run_test "Check if Ollama is running - failure" test_check_ollama_running_failure
+run_test "Check fails on HTTP error (wrong URL path)" test_check_ollama_fails_on_http_error
+run_test "Parse error shows raw response (with jq)" test_parse_error_shows_raw_response_with_jq
+run_test "Parse error shows raw response (without jq)" test_parse_error_shows_raw_response_without_jq
 run_test "Successful API call with jq available" test_successful_api_call_with_jq
 run_test "Successful API call without jq" test_successful_api_call_without_jq
 run_test "Handles API error response with jq" test_handles_api_error_response_with_jq

--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -103,9 +103,10 @@ test_checks_ollama_availability_before_querying() {
     local result=$?
     
     assert_equals "$result" "1"
-    assert_contains "$output" "Ollama is not running"
+    assert_contains "$output" "Ollama is not reachable"
     assert_contains "$output" "http://localhost:11434"
     assert_contains "$output" "ollama serve"
+    assert_contains "$output" "no /v1"
 
     teardown_test_env
 }

--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -93,20 +93,23 @@ test_checks_ollama_availability_before_querying() {
     export ZSH_AI_PROVIDER="ollama"
     export ZSH_AI_OLLAMA_URL="http://localhost:11434"
     
-    # Mock Ollama check to fail
+    # Mock Ollama check to fail (the real check prints the user-facing error itself)
     _zsh_ai_check_ollama() {
+        echo "Error: mock check failed"
         return 1
     }
-    
+
+    _zsh_ai_query_ollama() {
+        echo "should not run"
+    }
+
     local output
     output=$(_zsh_ai_query "test query")
     local result=$?
-    
+
     assert_equals "$result" "1"
-    assert_contains "$output" "Ollama is not reachable"
-    assert_contains "$output" "http://localhost:11434"
-    assert_contains "$output" "ollama serve"
-    assert_contains "$output" "no /v1"
+    assert_contains "$output" "Error: mock check failed"
+    assert_not_contains "$output" "should not run"
 
     teardown_test_env
 }

--- a/tests/utils.test.zsh
+++ b/tests/utils.test.zsh
@@ -106,7 +106,7 @@ test_checks_ollama_availability_before_querying() {
     assert_contains "$output" "Ollama is not running"
     assert_contains "$output" "http://localhost:11434"
     assert_contains "$output" "ollama serve"
-    
+
     teardown_test_env
 }
 
@@ -343,6 +343,39 @@ test_no_execution_happens() {
     teardown_test_env
 }
 
+test_works_with_noclobber_set() {
+    setup_test_env
+    export ZSH_AI_PROVIDER="anthropic"
+    export ANTHROPIC_API_KEY="test-key"
+
+    # Simulate a user with noclobber in their zshrc (issue #46):
+    # the tmpfile redirect must not fail on the file mktemp already created
+    setopt localoptions noclobber
+
+    # Mock query function
+    _zsh_ai_query() {
+        echo "ls -la"
+    }
+
+    # Mock print -z so the success path doesn't touch the buffer stack
+    print() {
+        if [[ "$1" == "-z" ]]; then
+            :
+        else
+            builtin print "$@"
+        fi
+    }
+
+    local output
+    output=$(zsh-ai "list files" 2>&1)
+    local result=$?
+
+    assert_equals "$result" "0"
+    assert_not_contains "$output" "Failed to generate command"
+
+    teardown_test_env
+}
+
 test_shows_loading_spinner() {
     setup_test_env
     export ZSH_AI_PROVIDER="anthropic"
@@ -521,6 +554,7 @@ run_test "Handles empty response in zsh-ai command" test_handles_empty_response_
 run_test "Combines multiple arguments in zsh-ai command" test_combines_multiple_arguments
 run_test "Puts generated command in buffer" test_puts_generated_command_in_buffer
 run_test "No execution happens" test_no_execution_happens
+run_test "Works with noclobber set" test_works_with_noclobber_set
 run_test "Shows loading spinner during command generation" test_shows_loading_spinner
 run_test "System prompt includes all rules" test_get_system_prompt_includes_all_rules
 run_test "System prompt handles complex context" test_get_system_prompt_with_complex_context


### PR DESCRIPTION
Follow-up to the [latest report on #46](https://github.com/matheusml/zsh-ai/issues/46#issuecomment-5025101844), which bundles two separate problems.

**noclobber breaks the plugin entirely.** Both the `# ...` widget and `zsh-ai` write the background query to a file mktemp already created, so with `setopt noclobber` the `>` redirect fails with "file exists" and every query dies. Both redirects now use `>|`, which exists exactly for this.

**A `/v1` suffix on `ZSH_AI_OLLAMA_URL` looked like a parse bug.** The plugin appends `/api/generate` itself, so the OpenAI-compat path 404s. `curl -s` exits 0 on 404, so the health check passed and the plain-text body surfaced later as "Unable to parse Ollama response", pointing users at the wrong thing. The health check now uses `curl -sf` so HTTP errors fail it, and the error names the actual fix (base URL, no `/v1`). Parse errors also echo the first 200 chars of the raw body so proxies and other weirdness are visible too.

Deliberately not done: `-f` on the generate call (Ollama sends real errors like "model not found" as JSON bodies on non-2xx, `-f` would swallow them), and auto-stripping `/v1` from the config (silently rewriting user config trades one confusing report for another).

