### PR TITLE
fix: allow configuring OpenAI token limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .npm
+.cptr

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,6 +137,8 @@ export ZSH_AI_OPENAI_API_KEY="sk-your-proxy-key"
 
 `ZSH_AI_OPENAI_REASONING_EFFORT` sets the `reasoning_effort` parameter for OpenAI-compatible endpoints that support it. For example, Groq supports `none` and `default` for `qwen/qwen3.6-27b`; set `none` to disable reasoning tokens. Common values are `none`, `default`, `minimal`, `low`, `medium`, and `high`; leave unset for upstream defaults.
 
+`ZSH_AI_OPENAI_MAX_TOKENS` sets the maximum number of tokens for the response. Increase this value for reasoning models to prevent the thinking process from being cut off, leading to "Failed to generate command" or "Unable to parse response" errors.
+
 ## Custom Provider
 
 Set `ZSH_AI_PROVIDER` to `custom` and define `_zsh_ai_query_custom` before `zsh-ai` loads. The function receives the natural-language query as its first argument. It must print only the generated command to standard output. If the provider fails, the function must print a message prefixed with `Error:` to the standard output, and/or return a non-zero status. This example uses the Codex CLI:

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -11,6 +11,7 @@
 : ${ZSH_AI_OPENAI_URL:="https://api.openai.com/v1/chat/completions"}  # Default to OpenAI
 : ${ZSH_AI_OPENAI_THINKING:=""}  # Configure thinking for supported models: 0 or 1, default unset/empty
 : ${ZSH_AI_OPENAI_REASONING_EFFORT:=""}  # Configure reasoning effort for supported OpenAI-compatible models
+: ${ZSH_AI_OPENAI_MAX_TOKENS:=256} # Maximum number of tokens per request; raise for reasoning models
 : ${ZSH_AI_QWEN_MODEL:="qwen-flash"}  # Default to qwen-flash (fast, low-cost Qwen3 tier)
 : ${ZSH_AI_QWEN_URL:="https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"}  # Default to Qwen API
 : ${ZSH_AI_ANTHROPIC_MODEL:="claude-haiku-4-5"}  # Default Anthropic model
@@ -67,6 +68,11 @@ _zsh_ai_validate_config() {
 
         if [[ -n "$ZSH_AI_OPENAI_THINKING" && "$ZSH_AI_OPENAI_THINKING" != "0" && "$ZSH_AI_OPENAI_THINKING" != "1" ]]; then
             echo "zsh-ai: Error: ZSH_AI_OPENAI_THINKING must be 0, 1, or unset."
+            return 1
+        fi
+        
+        if [[ -n "$ZSH_AI_OPENAI_MAX_TOKENS" && "$ZSH_AI_OPENAI_MAX_TOKENS" != <1-> ]]; then
+            echo "zsh-ai: Error: ZSH_AI_OPENAI_MAX_TOKENS must be a positive integer."
             return 1
         fi
 

--- a/lib/config.zsh
+++ b/lib/config.zsh
@@ -71,7 +71,7 @@ _zsh_ai_validate_config() {
             return 1
         fi
         
-        if [[ -n "$ZSH_AI_OPENAI_MAX_TOKENS" && "$ZSH_AI_OPENAI_MAX_TOKENS" != <1-> ]]; then
+        if [[ "$ZSH_AI_OPENAI_MAX_TOKENS" != <1-> ]]; then
             echo "zsh-ai: Error: ZSH_AI_OPENAI_MAX_TOKENS must be a positive integer."
             return 1
         fi

--- a/lib/providers/openai.zsh
+++ b/lib/providers/openai.zsh
@@ -46,6 +46,9 @@ _zsh_ai_query_openai() {
         reasoning_effort_param=$',\n    "reasoning_effort": "'"$(_zsh_ai_escape_json "$ZSH_AI_OPENAI_REASONING_EFFORT")"'"'
     fi
 
+    local max_tokens="${ZSH_AI_OPENAI_MAX_TOKENS:-256}"
+    [[ "$max_tokens" == <1-> ]] || max_tokens=256
+
     local json_payload=$(cat <<EOF
 {
     "model": "${ZSH_AI_OPENAI_MODEL}",
@@ -59,7 +62,7 @@ _zsh_ai_query_openai() {
             "content": "$escaped_query"
         }
     ],
-    "$token_param": ${ZSH_AI_OPENAI_MAX_TOKENS}${temperature_param}${thinking_param}${reasoning_effort_param}
+    "$token_param": ${max_tokens}${temperature_param}${thinking_param}${reasoning_effort_param}
 }
 EOF
 )

--- a/lib/providers/openai.zsh
+++ b/lib/providers/openai.zsh
@@ -59,7 +59,7 @@ _zsh_ai_query_openai() {
             "content": "$escaped_query"
         }
     ],
-    "$token_param": 256${temperature_param}${thinking_param}${reasoning_effort_param}
+    "$token_param": ${ZSH_AI_OPENAI_MAX_TOKENS:-256}${temperature_param}${thinking_param}${reasoning_effort_param}
 }
 EOF
 )

--- a/lib/providers/openai.zsh
+++ b/lib/providers/openai.zsh
@@ -59,7 +59,7 @@ _zsh_ai_query_openai() {
             "content": "$escaped_query"
         }
     ],
-    "$token_param": ${ZSH_AI_OPENAI_MAX_TOKENS:-256}${temperature_param}${thinking_param}${reasoning_effort_param}
+    "$token_param": ${ZSH_AI_OPENAI_MAX_TOKENS}${temperature_param}${thinking_param}${reasoning_effort_param}
 }
 EOF
 )

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -470,7 +470,43 @@ test_openai_reasoning_effort_escapes_value() {
     assert_contains "$captured_payload" '"reasoning_effort": "custom\"tier"'
 }
 
+
+# Tests for ZSH_AI_OPENAI_MAX_TOKENS
+echo ""
+echo "Running OpenAI-compatible max tokens tests..."
+
+test_openai_max_tokens_defaults_to_256() {
+    unset ZSH_AI_OPENAI_MAX_TOKENS
+    source "${PLUGIN_DIR}/lib/config.zsh"
+    local captured_payload=$(capture_openai_payload_for_model "gpt-5-mini")
+    assert_contains "$captured_payload" '"max_completion_tokens": 256'
+}
+
+test_openai_max_tokens_uses_custom_value() {
+    export ZSH_AI_OPENAI_MAX_TOKENS=2048
+    local captured_payload=$(capture_openai_payload_for_model "gpt-5-mini")
+    unset ZSH_AI_OPENAI_MAX_TOKENS
+    assert_contains "$captured_payload" '"max_completion_tokens": 2048'
+}
+
+test_openai_max_tokens_invalid_value_returns_error() {
+    unset ZSH_AI_OPENAI_THINKING
+    unset ZSH_AI_OPENAI_REASONING_EFFORT
+    unset ZSH_AI_OPENAI_MAX_TOKENS
+    export ZSH_AI_OPENAI_MAX_TOKENS="abc"
+    local result
+    result=$(_zsh_ai_validate_config 2>&1)
+    local exit_code=$?
+    assert_equals "$exit_code" "1"
+    assert_contains "$result" "ZSH_AI_OPENAI_MAX_TOKENS must be a positive integer"
+}
+
+run_test "ZSH_AI_OPENAI_MAX_TOKENS defaults to 256" test_openai_max_tokens_defaults_to_256
+run_test "ZSH_AI_OPENAI_MAX_TOKENS uses custom value" test_openai_max_tokens_uses_custom_value
+run_test "ZSH_AI_OPENAI_MAX_TOKENS invalid value returns error" test_openai_max_tokens_invalid_value_returns_error
+
 run_test "ZSH_AI_OPENAI_REASONING_EFFORT unset omits reasoning_effort parameter" test_openai_reasoning_effort_unset_omits_param
 run_test "ZSH_AI_OPENAI_REASONING_EFFORT sets reasoning_effort value" test_openai_reasoning_effort_sets_value
 run_test "ZSH_AI_OPENAI_REASONING_EFFORT escapes reasoning_effort value" test_openai_reasoning_effort_escapes_value
 finish_tests
+

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -433,6 +433,7 @@ test_openai_thinking_invalid_value_returns_error() {
 
     # Should not pass validation since it is not 0, 1, or unset
     assert_equals "$exit_code" "1"
+    unset ZSH_AI_OPENAI_THINKING
 }
 
 run_test "ZSH_AI_OPENAI_THINKING unset omits chat_template_kwargs parameter" test_openai_thinking_unset_omits_param
@@ -490,14 +491,12 @@ test_openai_max_tokens_uses_custom_value() {
 }
 
 test_openai_max_tokens_invalid_value_returns_error() {
-    unset ZSH_AI_OPENAI_THINKING
-    unset ZSH_AI_OPENAI_REASONING_EFFORT
-    unset ZSH_AI_OPENAI_MAX_TOKENS
     export ZSH_AI_OPENAI_MAX_TOKENS="abc"
     local result
     result=$(_zsh_ai_validate_config 2>&1)
     local exit_code=$?
     assert_equals "$exit_code" "1"
+    unset ZSH_AI_OPENAI_MAX_TOKENS
     assert_contains "$result" "ZSH_AI_OPENAI_MAX_TOKENS must be a positive integer"
 }
 

--- a/tests/providers/openai.test.zsh
+++ b/tests/providers/openai.test.zsh
@@ -500,9 +500,17 @@ test_openai_max_tokens_invalid_value_returns_error() {
     assert_contains "$result" "ZSH_AI_OPENAI_MAX_TOKENS must be a positive integer"
 }
 
+test_openai_max_tokens_invalid_fallback_to_256() {
+    export ZSH_AI_OPENAI_MAX_TOKENS="invalid"
+    local captured_payload=$(capture_openai_payload_for_model "gpt-5-mini")
+    unset ZSH_AI_OPENAI_MAX_TOKENS
+    assert_contains "$captured_payload" '"max_completion_tokens": 256'
+}
+
 run_test "ZSH_AI_OPENAI_MAX_TOKENS defaults to 256" test_openai_max_tokens_defaults_to_256
 run_test "ZSH_AI_OPENAI_MAX_TOKENS uses custom value" test_openai_max_tokens_uses_custom_value
 run_test "ZSH_AI_OPENAI_MAX_TOKENS invalid value returns error" test_openai_max_tokens_invalid_value_returns_error
+run_test "ZSH_AI_OPENAI_MAX_TOKENS invalid value falls back to 256 at runtime" test_openai_max_tokens_invalid_fallback_to_256
 
 run_test "ZSH_AI_OPENAI_REASONING_EFFORT unset omits reasoning_effort parameter" test_openai_reasoning_effort_unset_omits_param
 run_test "ZSH_AI_OPENAI_REASONING_EFFORT sets reasoning_effort value" test_openai_reasoning_effort_sets_value


### PR DESCRIPTION
When reasoning exceedes 256 tokens, the response contains an empty content field. This pull request adds the option to set a custom number of max tokens through the variable ZSH_AI_OPENAI_MAX_TOKENS
fixes issue #86